### PR TITLE
fix resize logic

### DIFF
--- a/image/imageIO.cpp
+++ b/image/imageIO.cpp
@@ -209,7 +209,7 @@ static unsigned char* loadImageIO( const char* filename, int* width, int* height
 	const int resizeWidth  = *width;
 	const int resizeHeight = *height;
 
-	if( resizeWidth > 0 && resizeHeight > 0 && resizeWidth != imgWidth && resizeHeight != imgHeight )
+	if( resizeWidth > 0 && resizeHeight > 0 && (resizeWidth != imgWidth || resizeHeight != imgHeight) )
 	{
 		unsigned char* img_org = img;
 


### PR DESCRIPTION
This would fix cuda memory access error when reading the images from the disk.

for example, if the desired resized resolution is 300x300, and the image being read is 1080 x 300, the api will not resize the image, and thus may throw cuda memory access error afterward.
