### PR TITLE
Minor change in strings for WIN32 build

### DIFF
--- a/image/imageFormat.inl
+++ b/image/imageFormat.inl
@@ -23,7 +23,12 @@
 #ifndef __IMAGE_FORMAT_INLINE_H_
 #define __IMAGE_FORMAT_INLINE_H_
 
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#else
 #include <strings.h>
+#endif
+
 #include <type_traits>
 
 


### PR DESCRIPTION
Minor change in removing strings.h header for building under WIN32.