### PR TITLE
[cudaResize] Added some interpolation filters. linear, area, cubic, lanczos4, spline36.

### DIFF
--- a/cuda/cudaMath.h
+++ b/cuda/cudaMath.h
@@ -362,31 +362,6 @@ inline __host__ __device__ uchar4 make_uchar4(float4 a)
     return make_uchar4(a.x, a.y, a.z, a.w);
 }
 
-inline __host__ __device__ void from_float4(const float4 a, uchar &dst)
-{
-	dst = uchar(a.x);
-}
-inline __host__ __device__ void from_float4(const float4 a, uchar3 &dst)
-{
-	dst = make_uchar3(a);
-}
-inline __host__ __device__ void from_float4(const float4 a, uchar4 &dst)
-{
-	dst = make_uchar4(a);
-}
-inline __host__ __device__ void from_float4(const float4 a, float &dst)
-{
-	dst = a.x;
-}
-inline __host__ __device__ void from_float4(const float4 a, float3 &dst)
-{
-	dst = make_float3(a);
-}
-inline __host__ __device__ void from_float4(const float4 a, float4 &dst)
-{
-	dst = a;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // negate
 ////////////////////////////////////////////////////////////////////////////////

--- a/cuda/cudaMath.h
+++ b/cuda/cudaMath.h
@@ -125,6 +125,10 @@ inline __host__ __device__ uint2 make_uint2(int2 a)
     return make_uint2(uint(a.x), uint(a.y));
 }
 
+inline __host__ __device__ float3 make_float3(uchar s)
+{
+    return make_float3(s, s, s);
+}
 inline __host__ __device__ float3 make_float3(float s)
 {
     return make_float3(s, s, s);
@@ -245,6 +249,10 @@ inline __host__ __device__ uchar3 make_uchar3(float4 a)
     return make_uchar3(a.x, a.y, a.z);
 }
 
+inline __host__ __device__ float4 make_float4(uchar s)
+{
+    return make_float4(s, s, s, s);
+}
 inline __host__ __device__ float4 make_float4(float s)
 {
     return make_float4(s, s, s, s);
@@ -352,6 +360,31 @@ inline __host__ __device__ uchar4 make_uchar4(float3 a)
 inline __host__ __device__ uchar4 make_uchar4(float4 a)
 {
     return make_uchar4(a.x, a.y, a.z, a.w);
+}
+
+inline __host__ __device__ void from_float4(const float4 a, uchar &dst)
+{
+	dst = uchar(a.x);
+}
+inline __host__ __device__ void from_float4(const float4 a, uchar3 &dst)
+{
+	dst = make_uchar3(a);
+}
+inline __host__ __device__ void from_float4(const float4 a, uchar4 &dst)
+{
+	dst = make_uchar4(a);
+}
+inline __host__ __device__ void from_float4(const float4 a, float &dst)
+{
+	dst = a.x;
+}
+inline __host__ __device__ void from_float4(const float4 a, float3 &dst)
+{
+	dst = make_float3(a);
+}
+inline __host__ __device__ void from_float4(const float4 a, float4 &dst)
+{
+	dst = a;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -520,6 +553,27 @@ inline __host__ __device__ void operator+=(uint3 &a, uint b)
     a.z += b;
 }
 
+inline __host__ __device__ uchar3 operator+(uchar3 a, uchar3 b)
+{
+    return make_uchar3(a.x + b.x, a.y + b.y, a.z + b.z);
+}
+inline __host__ __device__ void operator+=(uchar3 &a, uchar3 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+}
+inline __host__ __device__ uchar3 operator+(uchar3 a, uchar b)
+{
+    return make_uchar3(a.x + b, a.y + b, a.z + b);
+}
+inline __host__ __device__ void operator+=(uchar3 &a, uchar b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+}
+
 inline __host__ __device__ int3 operator+(int b, int3 a)
 {
     return make_int3(a.x + b, a.y + b, a.z + b);
@@ -531,6 +585,10 @@ inline __host__ __device__ uint3 operator+(uint b, uint3 a)
 inline __host__ __device__ float3 operator+(float b, float3 a)
 {
     return make_float3(a.x + b, a.y + b, a.z + b);
+}
+inline __host__ __device__ uchar3 operator+(uchar b, uchar3 a)
+{
+    return make_uchar3(a.x + b, a.y + b, a.z + b);
 }
 
 inline __host__ __device__ float4 operator+(float4 a, float4 b)
@@ -607,6 +665,33 @@ inline __host__ __device__ uint4 operator+(uint b, uint4 a)
     return make_uint4(a.x + b, a.y + b, a.z + b,  a.w + b);
 }
 inline __host__ __device__ void operator+=(uint4 &a, uint b)
+{
+    a.x += b;
+    a.y += b;
+    a.z += b;
+    a.w += b;
+}
+
+inline __host__ __device__ uchar4 operator+(uchar4 a, uchar4 b)
+{
+    return make_uchar4(a.x + b.x, a.y + b.y, a.z + b.z,  a.w + b.w);
+}
+inline __host__ __device__ void operator+=(uchar4 &a, uchar4 b)
+{
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+    a.w += b.w;
+}
+inline __host__ __device__ uchar4 operator+(uchar4 a, uchar b)
+{
+    return make_uchar4(a.x + b, a.y + b, a.z + b,  a.w + b);
+}
+inline __host__ __device__ uchar4 operator+(uchar b, uchar4 a)
+{
+    return make_uchar4(a.x + b, a.y + b, a.z + b,  a.w + b);
+}
+inline __host__ __device__ void operator+=(uchar4 &a, uchar b)
 {
     a.x += b;
     a.y += b;
@@ -986,6 +1071,20 @@ inline __host__ __device__ void operator*=(uint3 &a, uint b)
     a.y *= b;
     a.z *= b;
 }
+inline __host__ __device__ uchar3 operator*(uchar3 a, float b)
+{
+    return make_uchar3(a.x * b, a.y * b, a.z * b);
+}
+inline __host__ __device__ uchar3 operator*(float b, uchar3 a)
+{
+    return make_uchar3(b * a.x, b * a.y, b * a.z);
+}
+inline __host__ __device__ void operator*=(uchar3 &a, float b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+}
 
 inline __host__ __device__ float4 operator*(float4 a, float4 b)
 {
@@ -1061,6 +1160,33 @@ inline __host__ __device__ uint4 operator*(uint b, uint4 a)
     return make_uint4(b * a.x, b * a.y, b * a.z, b * a.w);
 }
 inline __host__ __device__ void operator*=(uint4 &a, uint b)
+{
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+    a.w *= b;
+}
+
+inline __host__ __device__ uchar4 operator*(uchar4 a, uchar4 b)
+{
+    return make_uchar4(a.x * b.x, a.y * b.y, a.z * b.z,  a.w * b.w);
+}
+inline __host__ __device__ void operator*=(uchar4 &a, uchar4 b)
+{
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+    a.w *= b.w;
+}
+inline __host__ __device__ uchar4 operator*(uchar4 a, uchar b)
+{
+    return make_uchar4(a.x * b, a.y * b, a.z * b,  a.w * b);
+}
+inline __host__ __device__ uchar4 operator*(uchar b, uchar4 a)
+{
+    return make_uchar4(b * a.x, b * a.y, b * a.z, b * a.w);
+}
+inline __host__ __device__ void operator*=(uchar4 &a, uchar b)
 {
     a.x *= b;
     a.y *= b;

--- a/cuda/cudaMath.h
+++ b/cuda/cudaMath.h
@@ -24,6 +24,9 @@
 #define __CUDA_HELPER_MATH_H_
 
 #include "cuda_runtime.h"
+#include <limits>
+#include <cfloat>
+#include <cmath>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @name Vector Math

--- a/cuda/cudaResize.cu
+++ b/cuda/cudaResize.cu
@@ -115,44 +115,44 @@ __global__ void gpuResize_area( float2 scale, T* input, int iWidth, int iHeight,
 		{
 			// inner rectangle.
 			for (int dx = sx1; dx < sx2; ++dx)
-				out += make_float4(input[dy * iWidth + dx]) * scale;
+				out += make_float4(input[dy * iWidth + dx]);
 
 			// v-edge line(left).
 			if (sx1 > fsx1)
-				out += make_float4(input[dy * iWidth + (sx1 -1)]) * ((sx1 - fsx1) * scale);
+				out += make_float4(input[dy * iWidth + (sx1 -1)]) * (sx1 - fsx1);
 
 			// v-edge line(right).
 			if (sx2 < fsx2)
-				out += make_float4(input[dy * iWidth + sx2]) * ((fsx2 -sx2) * scale);
+				out += make_float4(input[dy * iWidth + sx2]) * (fsx2 - sx2);
 		}
 
 		// h-edge line(top).
 		if (sy1 > fsy1)
 			for (int dx = sx1; dx < sx2; ++dx)
-				out += make_float4(input[(sy1 - 1) * iWidth + dx]) * ((sy1 -fsy1) * scale);
+				out += make_float4(input[(sy1 - 1) * iWidth + dx]) * (sy1 - fsy1);
 
 		// h-edge line(bottom).
 		if (sy2 < fsy2)
 			for (int dx = sx1; dx < sx2; ++dx)
-				out += make_float4(input[sy2 * iWidth + dx]) * ((fsy2 -sy2) * scale);
+				out += make_float4(input[sy2 * iWidth + dx]) * (fsy2 - sy2);
 
 		// corner(top, left).
 		if ((sy1 > fsy1) &&  (sx1 > fsx1))
-			out += make_float4(input[(sy1 - 1) * iWidth + (sx1 - 1)]) * ((sy1 -fsy1) * (sx1 -fsx1) * scale);
+			out += make_float4(input[(sy1 - 1) * iWidth + (sx1 - 1)]) * (sy1 - fsy1) * (sx1 - fsx1);
 
 		// corner(top, right).
 		if ((sy1 > fsy1) &&  (sx2 < fsx2))
-			out += make_float4(input[(sy1 - 1) * iWidth + sx2]) * ((sy1 -fsy1) * (fsx2 -sx2) * scale);
+			out += make_float4(input[(sy1 - 1) * iWidth + sx2]) * (sy1 - fsy1) * (fsx2 - sx2);
 
 		// corner(bottom, left).
 		if ((sy2 < fsy2) &&  (sx2 < fsx2))
-			out += make_float4(input[sy2 * iWidth + sx2]) * ((fsy2 -sy2) * (fsx2 -sx2) * scale);
+			out += make_float4(input[sy2 * iWidth + sx2]) * (fsy2 - sy2) * (fsx2 - sx2);
 
 		// corner(bottom, right).
 		if ((sy2 < fsy2) &&  (sx1 > fsx1))
-			out += make_float4(input[sy2 * iWidth + (sx1 - 1)]) * ((fsy2 -sy2) * (sx1 -fsx1) * scale);
+			out += make_float4(input[sy2 * iWidth + (sx1 - 1)]) * (fsy2 - sy2) * (sx1 - fsx1);
 
-		output[y * oWidth + x] = cast_vec<T>(out);
+		output[y * oWidth + x] = cast_vec<T>(out * scale);
 	}
 }
 
@@ -171,7 +171,7 @@ static cudaError_t launchResize( T* input, size_t inputWidth, size_t inputHeight
 							     float(inputHeight) / float(outputHeight) );
 
 	// launch kernel
-	const dim3 blockDim(8, 8);
+	const dim3 blockDim(32, 8);
 	const dim3 gridDim(iDivUp(outputWidth,blockDim.x), iDivUp(outputHeight,blockDim.y));
 
 	if (mode == static_cast<int>(InterpolationFlags::INTER_LINEAR)) {

--- a/cuda/cudaResize.cu
+++ b/cuda/cudaResize.cu
@@ -24,9 +24,9 @@
 
 
 
-// gpuResize
+// gpuResize. nearest.
 template<typename T>
-__global__ void gpuResize( float2 scale, T* input, int iWidth, T* output, int oWidth, int oHeight )
+__global__ void gpuResize_nearest( float2 scale, T* input, int iWidth, T* output, int oWidth, int oHeight )
 {
 	const int x = blockIdx.x * blockDim.x + threadIdx.x;
 	const int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -42,10 +42,124 @@ __global__ void gpuResize( float2 scale, T* input, int iWidth, T* output, int oW
 	output[y*oWidth+x] = px;
 }
 
+// gpuResize. linear.
+template <typename T>
+__global__ void gpuResize_linear( float2 scale, T* input, int iWidth, int iHeight, T* output, int oWidth, int oHeight )
+{
+	const int dst_x = blockDim.x * blockIdx.x + threadIdx.x;
+	const int dst_y = blockDim.y * blockIdx.y + threadIdx.y;
+
+	if (dst_x < oWidth && dst_y < oHeight)
+	{
+		const float src_x = dst_x * scale.x;
+		const float src_y = dst_y * scale.y;
+
+		const int x1 = __float2int_rd(src_x);
+		const int y1 = __float2int_rd(src_y);
+		const int x2 = x1 + 1;
+		const int y2 = y1 + 1;
+		const int x2_read = ::min(x2, iWidth - 1);
+		const int y2_read = ::min(y2, iHeight - 1);
+
+		float4 pix_in[4];
+		float weight[4];
+
+		pix_in[0] = make_float4(input[y1 * iWidth + x1]);
+		weight[0] = (x2 - src_x) * (y2 - src_y);
+
+		pix_in[1] = make_float4(input[y1 * iWidth + x2_read]);
+		weight[1] = (src_x - x1) * (y2 - src_y);
+
+		pix_in[2] = make_float4(input[y2_read * iWidth + x1]);
+		weight[2] = (x2 - src_x) * (src_y - y1);
+
+		pix_in[3] = make_float4(input[y2_read * iWidth + x2_read]);
+		weight[3] = (src_x - x1) * (src_y - y1);
+
+		float4 out = pix_in[0] * weight[0] + pix_in[1] * weight[1] + pix_in[2] * weight[2] + pix_in[3] * weight[3];
+
+		from_float4(out, output[dst_y * oWidth + dst_x]);
+	}
+}
+
+// gpuResize. area.
+template <typename T>
+__global__ void gpuResize_area( float2 scale, T* input, int iWidth, int iHeight, T* output, int oWidth, int oHeight )
+{
+	const int x = blockIdx.x * blockDim.x + threadIdx.x;
+	const int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+	if( x >= oWidth || y >= oHeight )
+		return;
+
+	{
+		float fsx1 = x * scale.x;
+		float fsx2 = ::min(fsx1 + scale.x, iWidth - 1.0f);
+
+		int sx1 = __float2int_ru(fsx1);
+		int sx2 = __float2int_rd(fsx2);
+
+		float fsy1 = y * scale.y;
+		float fsy2 = ::min(fsy1 + scale.y, iHeight - 1.0f);
+
+		int sy1 = __float2int_ru(fsy1);
+		int sy2 = __float2int_rd(fsy2);
+
+		float sx = ::min(float(scale.x), iWidth - fsx1);
+		float sy = ::min(float(scale.y), iHeight - fsy1);
+		float scale = 1.f / (sx * sy);
+
+		float4 out = {};
+
+		for (int dy = sy1; dy < sy2; ++dy)
+		{
+			// inner rectangle.
+			for (int dx = sx1; dx < sx2; ++dx)
+				out += make_float4(input[dy * iWidth + dx]) * scale;
+
+			// v-edge line(left).
+			if (sx1 > fsx1)
+				out += make_float4(input[dy * iWidth + (sx1 -1)]) * ((sx1 - fsx1) * scale);
+
+			// v-edge line(right).
+			if (sx2 < fsx2)
+				out += make_float4(input[dy * iWidth + sx2]) * ((fsx2 -sx2) * scale);
+		}
+
+		// h-edge line(top).
+		if (sy1 > fsy1)
+			for (int dx = sx1; dx < sx2; ++dx)
+				out += make_float4(input[(sy1 - 1) * iWidth + dx]) * ((sy1 -fsy1) * scale);
+
+		// h-edge line(bottom).
+		if (sy2 < fsy2)
+			for (int dx = sx1; dx < sx2; ++dx)
+				out += make_float4(input[sy2 * iWidth + dx]) * ((fsy2 -sy2) * scale);
+
+		// corner(top, left).
+		if ((sy1 > fsy1) &&  (sx1 > fsx1))
+			out += make_float4(input[(sy1 - 1) * iWidth + (sx1 - 1)]) * ((sy1 -fsy1) * (sx1 -fsx1) * scale);
+
+		// corner(top, right).
+		if ((sy1 > fsy1) &&  (sx2 < fsx2))
+			out += make_float4(input[(sy1 - 1) * iWidth + sx2]) * ((sy1 -fsy1) * (fsx2 -sx2) * scale);
+
+		// corner(bottom, left).
+		if ((sy2 < fsy2) &&  (sx2 < fsx2))
+			out += make_float4(input[sy2 * iWidth + sx2]) * ((fsy2 -sy2) * (fsx2 -sx2) * scale);
+
+		// corner(bottom, right).
+		if ((sy2 < fsy2) &&  (sx1 > fsx1))
+			out += make_float4(input[sy2 * iWidth + (sx1 - 1)]) * ((fsy2 -sy2) * (sx1 -fsx1) * scale);
+
+		from_float4(out, output[y * oWidth + x]);
+	}
+}
+
 // launchResize
 template<typename T>
 static cudaError_t launchResize( T* input, size_t inputWidth, size_t inputHeight,
-				             T* output, size_t outputWidth, size_t outputHeight )
+				             T* output, size_t outputWidth, size_t outputHeight, int mode )
 {
 	if( !input || !output )
 		return cudaErrorInvalidDevicePointer;
@@ -60,63 +174,79 @@ static cudaError_t launchResize( T* input, size_t inputWidth, size_t inputHeight
 	const dim3 blockDim(8, 8);
 	const dim3 gridDim(iDivUp(outputWidth,blockDim.x), iDivUp(outputHeight,blockDim.y));
 
-	gpuResize<T><<<gridDim, blockDim>>>(scale, input, inputWidth, output, outputWidth, outputHeight);
+	if (mode == static_cast<int>(InterpolationFlags::INTER_LINEAR)) {
+		if (inputWidth == outputWidth && inputHeight == outputHeight) {
+			gpuResize_nearest<T><<<gridDim, blockDim>>>(scale, input, inputWidth, output, outputWidth, outputHeight);
+		} else {
+			gpuResize_linear<T><<<gridDim, blockDim>>>(scale, input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+		}
+	} else if (mode == static_cast<int>(InterpolationFlags::INTER_AREA)) {
+		if (inputWidth > outputWidth && inputHeight > outputHeight) {
+			gpuResize_area<T><<<gridDim, blockDim>>>(scale, input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+		} else if (inputWidth == outputWidth && inputHeight == outputHeight) {
+			gpuResize_nearest<T><<<gridDim, blockDim>>>(scale, input, inputWidth, output, outputWidth, outputHeight);
+		} else {
+			gpuResize_linear<T><<<gridDim, blockDim>>>(scale, input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+		}
+	} else {
+		gpuResize_nearest<T><<<gridDim, blockDim>>>(scale, input, inputWidth, output, outputWidth, outputHeight);
+	}
 
 	return CUDA(cudaGetLastError());
 }
 
 // cudaResize (uint8 grayscale)
-cudaError_t cudaResize( uint8_t* input, size_t inputWidth, size_t inputHeight, uint8_t* output, size_t outputWidth, size_t outputHeight )
+cudaError_t cudaResize( uint8_t* input, size_t inputWidth, size_t inputHeight, uint8_t* output, size_t outputWidth, size_t outputHeight, int mode )
 {
-	return launchResize<uint8_t>(input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+	return launchResize<uint8_t>(input, inputWidth, inputHeight, output, outputWidth, outputHeight, mode);
 }
 
 // cudaResize (float grayscale)
-cudaError_t cudaResize( float* input, size_t inputWidth, size_t inputHeight, float* output, size_t outputWidth, size_t outputHeight )
+cudaError_t cudaResize( float* input, size_t inputWidth, size_t inputHeight, float* output, size_t outputWidth, size_t outputHeight, int mode )
 {
-	return launchResize<float>(input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+	return launchResize<float>(input, inputWidth, inputHeight, output, outputWidth, outputHeight, mode);
 }
 
 // cudaResize (uchar3)
-cudaError_t cudaResize( uchar3* input, size_t inputWidth, size_t inputHeight, uchar3* output, size_t outputWidth, size_t outputHeight )
+cudaError_t cudaResize( uchar3* input, size_t inputWidth, size_t inputHeight, uchar3* output, size_t outputWidth, size_t outputHeight, int mode )
 {
-	return launchResize<uchar3>(input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+	return launchResize<uchar3>(input, inputWidth, inputHeight, output, outputWidth, outputHeight, mode);
 }
 
 // cudaResize (uchar4)
-cudaError_t cudaResize( uchar4* input, size_t inputWidth, size_t inputHeight, uchar4* output, size_t outputWidth, size_t outputHeight )
+cudaError_t cudaResize( uchar4* input, size_t inputWidth, size_t inputHeight, uchar4* output, size_t outputWidth, size_t outputHeight, int mode )
 {
-	return launchResize<uchar4>(input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+	return launchResize<uchar4>(input, inputWidth, inputHeight, output, outputWidth, outputHeight, mode);
 }
 
 // cudaResize (float3)
-cudaError_t cudaResize( float3* input, size_t inputWidth, size_t inputHeight, float3* output, size_t outputWidth, size_t outputHeight )
+cudaError_t cudaResize( float3* input, size_t inputWidth, size_t inputHeight, float3* output, size_t outputWidth, size_t outputHeight, int mode )
 {
-	return launchResize<float3>(input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+	return launchResize<float3>(input, inputWidth, inputHeight, output, outputWidth, outputHeight, mode);
 }
 
 // cudaResize (float4)
-cudaError_t cudaResize( float4* input, size_t inputWidth, size_t inputHeight, float4* output, size_t outputWidth, size_t outputHeight )
+cudaError_t cudaResize( float4* input, size_t inputWidth, size_t inputHeight, float4* output, size_t outputWidth, size_t outputHeight, int mode )
 {
-	return launchResize<float4>(input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+	return launchResize<float4>(input, inputWidth, inputHeight, output, outputWidth, outputHeight, mode);
 }
 
 //-----------------------------------------------------------------------------------
 cudaError_t cudaResize( void* input,  size_t inputWidth,  size_t inputHeight,
-				    void* output, size_t outputWidth, size_t outputHeight, imageFormat format )
+				    void* output, size_t outputWidth, size_t outputHeight, imageFormat format, int mode )
 {
 	if( format == IMAGE_RGB8 || format == IMAGE_BGR8 )
-		return cudaResize((uchar3*)input, inputWidth, inputHeight, (uchar3*)output, outputWidth, outputHeight);
+		return cudaResize((uchar3*)input, inputWidth, inputHeight, (uchar3*)output, outputWidth, outputHeight, mode);
 	else if( format == IMAGE_RGBA8 || format == IMAGE_BGRA8 )
-		return cudaResize((uchar4*)input, inputWidth, inputHeight, (uchar4*)output, outputWidth, outputHeight);
+		return cudaResize((uchar4*)input, inputWidth, inputHeight, (uchar4*)output, outputWidth, outputHeight, mode);
 	else if( format == IMAGE_RGB32F || format == IMAGE_BGR32F )
-		return cudaResize((float3*)input, inputWidth, inputHeight, (float3*)output, outputWidth, outputHeight);
+		return cudaResize((float3*)input, inputWidth, inputHeight, (float3*)output, outputWidth, outputHeight, mode);
 	else if( format == IMAGE_RGBA32F || format == IMAGE_BGRA32F )
-		return cudaResize((float4*)input, inputWidth, inputHeight, (float4*)output, outputWidth, outputHeight);
+		return cudaResize((float4*)input, inputWidth, inputHeight, (float4*)output, outputWidth, outputHeight, mode);
 	else if( format == IMAGE_GRAY8 )
-		return cudaResize((uint8_t*)input, inputWidth, inputHeight, (uint8_t*)output, outputWidth, outputHeight);
+		return cudaResize((uint8_t*)input, inputWidth, inputHeight, (uint8_t*)output, outputWidth, outputHeight, mode);
 	else if( format == IMAGE_GRAY32F )
-		return cudaResize((float*)input, inputWidth, inputHeight, (float*)output, outputWidth, outputHeight);
+		return cudaResize((float*)input, inputWidth, inputHeight, (float*)output, outputWidth, outputHeight, mode);
 
 	LogError(LOG_CUDA "cudaResize() -- invalid image format '%s'\n", imageFormatToStr(format));
 	LogError(LOG_CUDA "                supported formats are:\n");

--- a/cuda/cudaResize.cu
+++ b/cuda/cudaResize.cu
@@ -78,7 +78,7 @@ __global__ void gpuResize_linear( float2 scale, T* input, int iWidth, int iHeigh
 
 		float4 out = pix_in[0] * weight[0] + pix_in[1] * weight[1] + pix_in[2] * weight[2] + pix_in[3] * weight[3];
 
-		from_float4(out, output[dst_y * oWidth + dst_x]);
+		output[dst_y * oWidth + dst_x] = cast_vec<T>(out);
 	}
 }
 
@@ -152,7 +152,7 @@ __global__ void gpuResize_area( float2 scale, T* input, int iWidth, int iHeight,
 		if ((sy2 < fsy2) &&  (sx1 > fsx1))
 			out += make_float4(input[sy2 * iWidth + (sx1 - 1)]) * ((fsy2 -sy2) * (sx1 -fsx1) * scale);
 
-		from_float4(out, output[y * oWidth + x]);
+		output[y * oWidth + x] = cast_vec<T>(out);
 	}
 }
 

--- a/cuda/cudaResize.cu
+++ b/cuda/cudaResize.cu
@@ -181,12 +181,12 @@ static cudaError_t launchResize( T* input, size_t inputWidth, size_t inputHeight
 			gpuResize_linear<T><<<gridDim, blockDim>>>(scale, input, inputWidth, inputHeight, output, outputWidth, outputHeight);
 		}
 	} else if (mode == static_cast<int>(InterpolationFlags::INTER_AREA)) {
-		if (inputWidth > outputWidth && inputHeight > outputHeight) {
-			gpuResize_area<T><<<gridDim, blockDim>>>(scale, input, inputWidth, inputHeight, output, outputWidth, outputHeight);
-		} else if (inputWidth == outputWidth && inputHeight == outputHeight) {
+		if (inputWidth == outputWidth && inputHeight == outputHeight) {
 			gpuResize_nearest<T><<<gridDim, blockDim>>>(scale, input, inputWidth, output, outputWidth, outputHeight);
-		} else {
+		} else if (inputWidth < outputWidth || inputHeight < outputHeight) {
 			gpuResize_linear<T><<<gridDim, blockDim>>>(scale, input, inputWidth, inputHeight, output, outputWidth, outputHeight);
+		} else {
+			gpuResize_area<T><<<gridDim, blockDim>>>(scale, input, inputWidth, inputHeight, output, outputWidth, outputHeight);
 		}
 	} else {
 		gpuResize_nearest<T><<<gridDim, blockDim>>>(scale, input, inputWidth, output, outputWidth, outputHeight);

--- a/cuda/cudaResize.h
+++ b/cuda/cudaResize.h
@@ -31,10 +31,11 @@
 enum class InterpolationFlags : int {
     INTER_NEAREST        = 0,
     INTER_LINEAR         = 1,
-    // INTER_CUBIC          = 2,
+    INTER_CUBIC          = 2,
     INTER_AREA           = 3,
-    // INTER_LANCZOS4       = 4,
+    INTER_LANCZOS4       = 4,
     // INTER_LINEAR_EXACT = 5,
+    INTER_SPLINE36       = 6,
     INTER_MAX            = 7,
 };
 
@@ -44,42 +45,42 @@ enum class InterpolationFlags : int {
  * @ingroup resize
  */
 cudaError_t cudaResize( uint8_t* input,  size_t inputWidth,  size_t inputHeight,
-				    uint8_t* output, size_t outputWidth, size_t outputHeight, int mode );
+				    uint8_t* output, size_t outputWidth, size_t outputHeight, int mode, float max_value = 255.0f );
 
 /**
  * Rescale a floating-point grayscale image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( float* input,  size_t inputWidth,  size_t inputHeight,
-				    float* output, size_t outputWidth, size_t outputHeight, int mode );
+				    float* output, size_t outputWidth, size_t outputHeight, int mode, float max_value = FLT_MAX );
 
 /**
  * Rescale a uchar3 RGB/BGR image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( uchar3* input,  size_t inputWidth,  size_t inputHeight,
-				    uchar3* output, size_t outputWidth, size_t outputHeight, int mode );
+				    uchar3* output, size_t outputWidth, size_t outputHeight, int mode, float max_value = 255.0f );
 
 /**
  * Rescale a float3 RGB/BGR image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( float3* input,  size_t inputWidth,  size_t inputHeight,
-				    float3* output, size_t outputWidth, size_t outputHeight, int mode );
+				    float3* output, size_t outputWidth, size_t outputHeight, int mode, float max_value = FLT_MAX );
 
 /**
  * Rescale a uchar4 RGBA/BGRA image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( uchar4* input,  size_t inputWidth,  size_t inputHeight,
-				    uchar4* output, size_t outputWidth, size_t outputHeight, int mode );
+				    uchar4* output, size_t outputWidth, size_t outputHeight, int mode, float max_value = 255.0f );
 
 /**
  * Rescale a float4 RGBA/BGRA image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( float4* input,  size_t inputWidth,  size_t inputHeight,
-				    float4* output, size_t outputWidth, size_t outputHeight, int mode );
+				    float4* output, size_t outputWidth, size_t outputHeight, int mode, float max_value = FLT_MAX );
 
 /**
  * Rescale an image on the GPU (supports grayscale, RGB/BGR, RGBA/BGRA)

--- a/cuda/cudaResize.h
+++ b/cuda/cudaResize.h
@@ -25,7 +25,18 @@
 
 
 #include "cudaUtility.h"
+#include "cudaVector.h"
 #include "imageFormat.h"
+
+enum class InterpolationFlags : int {
+    INTER_NEAREST        = 0,
+    INTER_LINEAR         = 1,
+    // INTER_CUBIC          = 2,
+    INTER_AREA           = 3,
+    // INTER_LANCZOS4       = 4,
+    // INTER_LINEAR_EXACT = 5,
+    INTER_MAX            = 7,
+};
 
 
 /**
@@ -33,42 +44,42 @@
  * @ingroup resize
  */
 cudaError_t cudaResize( uint8_t* input,  size_t inputWidth,  size_t inputHeight,
-				    uint8_t* output, size_t outputWidth, size_t outputHeight );
+				    uint8_t* output, size_t outputWidth, size_t outputHeight, int mode );
 
 /**
  * Rescale a floating-point grayscale image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( float* input,  size_t inputWidth,  size_t inputHeight,
-				    float* output, size_t outputWidth, size_t outputHeight );
+				    float* output, size_t outputWidth, size_t outputHeight, int mode );
 
 /**
  * Rescale a uchar3 RGB/BGR image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( uchar3* input,  size_t inputWidth,  size_t inputHeight,
-				    uchar3* output, size_t outputWidth, size_t outputHeight );
+				    uchar3* output, size_t outputWidth, size_t outputHeight, int mode );
 
 /**
  * Rescale a float3 RGB/BGR image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( float3* input,  size_t inputWidth,  size_t inputHeight,
-				    float3* output, size_t outputWidth, size_t outputHeight );
+				    float3* output, size_t outputWidth, size_t outputHeight, int mode );
 
 /**
  * Rescale a uchar4 RGBA/BGRA image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( uchar4* input,  size_t inputWidth,  size_t inputHeight,
-				    uchar4* output, size_t outputWidth, size_t outputHeight );
+				    uchar4* output, size_t outputWidth, size_t outputHeight, int mode );
 
 /**
  * Rescale a float4 RGBA/BGRA image on the GPU.
  * @ingroup resize
  */
 cudaError_t cudaResize( float4* input,  size_t inputWidth,  size_t inputHeight,
-				    float4* output, size_t outputWidth, size_t outputHeight );
+				    float4* output, size_t outputWidth, size_t outputHeight, int mode );
 
 /**
  * Rescale an image on the GPU (supports grayscale, RGB/BGR, RGBA/BGRA)
@@ -76,7 +87,7 @@ cudaError_t cudaResize( float4* input,  size_t inputWidth,  size_t inputHeight,
  */
 cudaError_t cudaResize( void* input,  size_t inputWidth,  size_t inputHeight,
 				    void* output, size_t outputWidth, size_t outputHeight, 
-				    imageFormat format );
+				    imageFormat format, int mode );
 
 #endif
 

--- a/cuda/cudaVector.h
+++ b/cuda/cudaVector.h
@@ -73,21 +73,29 @@ template<typename T> inline __host__ __device__ T cast_vec( const uchar4& a )			
 template<typename T> inline __host__ __device__ T cast_vec( const float3& a )				{ static_assert(cuda_assert_false<T>::value, "invalid vector type - supported types are uchar3, uchar4, float3, float4");  }
 template<typename T> inline __host__ __device__ T cast_vec( const float4& a )				{ static_assert(cuda_assert_false<T>::value, "invalid vector type - supported types are uchar3, uchar4, float3, float4");  }
 
+template<> inline __host__ __device__ uchar  cast_vec( const uchar3& a )					{ return a.x; }
+template<> inline __host__ __device__ float  cast_vec( const uchar3& a )					{ return float(a.x); }
 template<> inline __host__ __device__ uchar3 cast_vec( const uchar3& a )					{ return make_uchar3(a); }
 template<> inline __host__ __device__ uchar4 cast_vec( const uchar3& a )					{ return make_uchar4(a); }
 template<> inline __host__ __device__ float3 cast_vec( const uchar3& a )					{ return make_float3(a); }
 template<> inline __host__ __device__ float4 cast_vec( const uchar3& a )					{ return make_float4(a); }
 
+template<> inline __host__ __device__ uchar  cast_vec( const uchar4& a )					{ return a.x; }
+template<> inline __host__ __device__ float  cast_vec( const uchar4& a )					{ return float(a.x); }
 template<> inline __host__ __device__ uchar3 cast_vec( const uchar4& a )					{ return make_uchar3(a); }
 template<> inline __host__ __device__ uchar4 cast_vec( const uchar4& a )					{ return make_uchar4(a); }
 template<> inline __host__ __device__ float3 cast_vec( const uchar4& a )					{ return make_float3(a); }
 template<> inline __host__ __device__ float4 cast_vec( const uchar4& a )					{ return make_float4(a); }
 
+template<> inline __host__ __device__ uchar  cast_vec( const float3& a )					{ return uchar(a.x); }
+template<> inline __host__ __device__ float  cast_vec( const float3& a )					{ return a.x; }
 template<> inline __host__ __device__ uchar3 cast_vec( const float3& a )					{ return make_uchar3(a); }
 template<> inline __host__ __device__ uchar4 cast_vec( const float3& a )					{ return make_uchar4(a); }
 template<> inline __host__ __device__ float3 cast_vec( const float3& a )					{ return make_float3(a); }
 template<> inline __host__ __device__ float4 cast_vec( const float3& a )					{ return make_float4(a); }
 
+template<> inline __host__ __device__ uchar  cast_vec( const float4& a )					{ return uchar(a.x); }
+template<> inline __host__ __device__ float  cast_vec( const float4& a )					{ return a.x; }
 template<> inline __host__ __device__ uchar3 cast_vec( const float4& a )					{ return make_uchar3(a); }
 template<> inline __host__ __device__ uchar4 cast_vec( const float4& a )					{ return make_uchar4(a); }
 template<> inline __host__ __device__ float3 cast_vec( const float4& a )					{ return make_float3(a); }

--- a/python/bindings/PyCUDA.cpp
+++ b/python/bindings/PyCUDA.cpp
@@ -1069,10 +1069,11 @@ PyObject* PyCUDA_Resize( PyObject* self, PyObject* args, PyObject* kwds )
 	// parse arguments
 	PyObject* pyInput  = NULL;
 	PyObject* pyOutput = NULL;
+	long mode = 0L;
 	
-	static char* kwlist[] = {"input", "output", NULL};
+	static char* kwlist[] = {"input", "output", "mode", NULL};
 
-	if( !PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist, &pyInput, &pyOutput))
+	if( !PyArg_ParseTupleAndKeywords(args, kwds, "OO|l", kwlist, &pyInput, &pyOutput, &mode))
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "cudaResize() failed to parse args");
 		return NULL;
@@ -1095,7 +1096,7 @@ PyObject* PyCUDA_Resize( PyObject* self, PyObject* args, PyObject* kwds )
 	}
 
 	// run the CUDA function
-	if( CUDA_FAILED(cudaResize(input->base.ptr, input->width, input->height, output->base.ptr, output->width, output->height, output->format)) )
+	if( CUDA_FAILED(cudaResize(input->base.ptr, input->width, input->height, output->base.ptr, output->width, output->height, output->format, mode)) )
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "cudaResize() failed");
 		return NULL;

--- a/python/examples/cuda-examples.py
+++ b/python/examples/cuda-examples.py
@@ -62,7 +62,9 @@ def resize(img, resize_factor):
 									   height=img.height * resize_factor[1],
 									   format=img.format)
 
-	jetson.utils.cudaResize(img, resized_img)
+	# interpolation filter types are:
+	#  INTER_NEAREST(default), INTER_LINEAR, INTER_AREA
+	jetson.utils.cudaResize(img, resized_img, jetson.utils.INTER_AREA)
 	return resized_img
 
 

--- a/python/examples/cuda-examples.py
+++ b/python/examples/cuda-examples.py
@@ -63,7 +63,7 @@ def resize(img, resize_factor):
 									   format=img.format)
 
 	# interpolation filter types are:
-	#  INTER_NEAREST(default), INTER_LINEAR, INTER_AREA
+	#  INTER_NEAREST(default), INTER_LINEAR, INTER_AREA, INTER_CUBIC, INTER_LANCZOS4, INTER_SPLINE36
 	jetson.utils.cudaResize(img, resized_img, jetson.utils.INTER_AREA)
 	return resized_img
 

--- a/python/python/Jetson/Utils/__init__.py
+++ b/python/python/Jetson/Utils/__init__.py
@@ -4,3 +4,7 @@
 from jetson_utils_python import *
 
 VERSION = '1.0.0'
+INTER_NEAREST        = 0
+INTER_LINEAR         = 1
+# INTER_CUBIC          = 2
+INTER_AREA           = 3

--- a/python/python/Jetson/Utils/__init__.py
+++ b/python/python/Jetson/Utils/__init__.py
@@ -6,5 +6,7 @@ from jetson_utils_python import *
 VERSION = '1.0.0'
 INTER_NEAREST        = 0
 INTER_LINEAR         = 1
-# INTER_CUBIC          = 2
+INTER_CUBIC          = 2
 INTER_AREA           = 3
+INTER_LANCZOS4       = 4
+INTER_SPLINE36       = 6

--- a/python/python/jetson/utils/__init__.py
+++ b/python/python/jetson/utils/__init__.py
@@ -4,3 +4,7 @@
 from jetson_utils_python import *
 
 VERSION = '1.0.0'
+INTER_NEAREST        = 0
+INTER_LINEAR         = 1
+# INTER_CUBIC          = 2
+INTER_AREA           = 3

--- a/python/python/jetson/utils/__init__.py
+++ b/python/python/jetson/utils/__init__.py
@@ -6,5 +6,7 @@ from jetson_utils_python import *
 VERSION = '1.0.0'
 INTER_NEAREST        = 0
 INTER_LINEAR         = 1
-# INTER_CUBIC          = 2
+INTER_CUBIC          = 2
 INTER_AREA           = 3
+INTER_LANCZOS4       = 4
+INTER_SPLINE36       = 6


### PR DESCRIPTION
- Added some interpolation filters.
- Added an optional parameter to specify the interpolation filter type at 'cudaResize'.
- Added definitions of interpolation filter type.

Interpolation filter types:
default is **INTER_NEAREST**.
> INTER_NEAREST
> INTER_LINEAR
> INTER_CUBIC
> INTER_AREA
> INTER_LANCZOS4
> INTER_SPLINE36
- If original image size and resized image size are same, always behave as **INTER_NEAREST**.
- In case of INTER_AREA, if resized image size is larger than original images size, behave as **INTER_LINEAR**. 

Example,
Python:
> jetson.utils.cudaResize(src_img, dst_img, **jetson.utils.INTER_AREA**)
