### PR TITLE
Fixed VP8, VP9 encode option.

### DIFF
--- a/codec/gstEncoder.cpp
+++ b/codec/gstEncoder.cpp
@@ -366,7 +366,11 @@ bool gstEncoder::buildLaunchStr()
 		else if( mOptions.codec == videoOptions::CODEC_MJPEG )
 			ss << "rtpjpegpay";
 
-		ss << " config-interval=1 ! udpsink host=";
+		if (mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265) {
+				ss << " config-interval=1 ! udpsink host=";
+		} else {
+				ss << " ! udpsink host=";
+		}
 		ss << uri.location << " ";
 
 		if( uri.port != 0 )


### PR DESCRIPTION
VP8 and VP9 are not support 'config-interval' option for encoding with GStreamer.
