### PR TITLE
Add support to videoOutput RTMP

### DIFF
--- a/codec/gstEncoder.cpp
+++ b/codec/gstEncoder.cpp
@@ -380,6 +380,28 @@ bool gstEncoder::buildLaunchStr()
 
 		mOptions.deviceType = videoOptions::DEVICE_IP;
 	}
+	else if( uri.protocol == "rtmp" )
+	{
+		if( mOptions.codec == videoOptions::CODEC_H264 )
+			ss << "rtph264pay";
+		else if( mOptions.codec == videoOptions::CODEC_H265 )
+			ss << "rtph265pay";
+		else if( mOptions.codec == videoOptions::CODEC_VP8 )
+			ss << "rtpvp8pay";
+		else if( mOptions.codec == videoOptions::CODEC_VP9 )
+			ss << "rtpvp9pay";
+		else if( mOptions.codec == videoOptions::CODEC_MJPEG )
+			ss << "rtpjpegpay";
+
+		if (mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265) {
+				ss << " config-interval=1 ! rtmpsink location=rtmp://";
+		} else {
+				ss << " ! rtmpsink location=rtmp://";
+		}
+		ss << uri.location << " ";
+
+		mOptions.deviceType = videoOptions::DEVICE_IP;
+	}
 
 	mLaunchStr = ss.str();
 

--- a/video/videoOutput.cpp
+++ b/video/videoOutput.cpp
@@ -80,7 +80,7 @@ videoOutput* videoOutput::Create( const videoOptions& options )
 		else
 			output = imageWriter::Create(options);
 	}
-	else if( uri.protocol == "rtp" )
+	else if( uri.protocol == "rtp" || uri.protocol == "rtmp" )
 	{
 		output = gstEncoder::Create(options);
 	}


### PR DESCRIPTION
Hello, I have an application that sends RTMP streams to a server.
This is really useful feature since it doesn't require network configuration to send video somewhere specially on edge iot devices. i know we have udp but some server doesn't support that. 
I made some changes to the code, i'm not a expert but it can be the beginning of this feature that should not require a lot of work since is very similar to udpsink.

the code should work like this
```
jetson.utils.videoOutput('rtmp://{url of the server}')
```

https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-bad/html/gst-plugins-bad-plugins-rtmpsink.html