### PR TITLE
fix missing return values

### DIFF
--- a/codec/gstUtility.cpp
+++ b/codec/gstUtility.cpp
@@ -126,6 +126,7 @@ videoOptions::Codec gst_parse_codec( GstStructure* caps )
 	}
 	
 	LogError(LOG_GSTREAMER "unrecognized codec - %s\n", codec);
+	return videoOptions::CODEC_UNKNOWN;
 }
 
 const char* gst_codec_to_string( videoOptions::Codec codec )

--- a/cuda/cudaBayer.cpp
+++ b/cuda/cudaBayer.cpp
@@ -61,6 +61,7 @@ cudaError_t cudaBayerToRGB( uint8_t* input, uchar3* output, size_t width, size_t
 		LogError(LOG_CUDA "cudaBayerToRGB() NPP error %i\n", result);
 		return cudaErrorUnknown;
 	}
+	return cudaSuccess;
 }
 
 

--- a/threads/Process.cpp
+++ b/threads/Process.cpp
@@ -29,14 +29,14 @@
 // GetID
 pid_t Process::GetID()
 {
-	getpid();
+	return getpid();
 }
 	
 
 // GetParentID
 pid_t Process::GetParentID()
 {
-	getppid();
+	return getppid();
 }
 
 

--- a/video/videoOptions.cpp
+++ b/video/videoOptions.cpp
@@ -215,6 +215,7 @@ const char* videoOptions::IoTypeToStr( videoOptions::IoType type )
 		case INPUT:  return "input";
 		case OUTPUT: return "output";
 	}
+	return nullptr;
 }
 
 
@@ -248,6 +249,7 @@ const char* videoOptions::DeviceTypeToStr( videoOptions::DeviceType type )
 		case DEVICE_FILE:		return "file";
 		case DEVICE_DISPLAY:	return "display";
 	}
+	return nullptr;
 }
 
 
@@ -283,6 +285,7 @@ const char* videoOptions::FlipMethodToStr( videoOptions::FlipMethod flip )
 		case FLIP_VERTICAL:				return "vertical";
 		case FLIP_UPPER_LEFT_DIAGONAL:	return "upper-left-diagonal";
 	}
+	return nullptr;
 }
 
 
@@ -319,6 +322,7 @@ const char* videoOptions::CodecToStr( videoOptions::Codec codec )
 		case CODEC_MPEG4:	return "mpeg4";
 		case CODEC_MJPEG:	return "mjpeg";
 	}
+	return nullptr;
 }
 
 

--- a/video/videoOutput.h
+++ b/video/videoOutput.h
@@ -244,7 +244,7 @@ public:
 	/**
 	 * Return the number of sub-streams.
 	 */
-	inline uint32_t GetNumOutputs( videoOutput* output ) const	{ mOutputs.size(); }
+	inline uint32_t GetNumOutputs() const	{ return mOutputs.size(); }
 
 	/**
 	 * Return a sub-stream.


### PR DESCRIPTION
Like that similar pull request #941 of jetson-inference, for video/videoOptions.cpp, I'm not quite sure by adding return nullptr is a very good idea