### PR TITLE
Fix bug where rotated video got the wrong aspect ratio

### DIFF
--- a/codec/gstDecoder.cpp
+++ b/codec/gstDecoder.cpp
@@ -355,8 +355,15 @@ bool gstDecoder::discover()
 	}
 	
 	// retrieve video resolution
-	const guint width  = gst_discoverer_video_info_get_width(videoInfo);
-	const guint height = gst_discoverer_video_info_get_height(videoInfo);
+	guint width  = gst_discoverer_video_info_get_width(videoInfo);
+	guint height = gst_discoverer_video_info_get_height(videoInfo);
+	if( mOptions.flipMethod == videoOptions::FLIP_CLOCKWISE || mOptions.flipMethod == videoOptions::FLIP_COUNTERCLOCKWISE
+		|| mOptions.flipMethod == videoOptions::FLIP_UPPER_LEFT_DIAGONAL || mOptions.flipMethod == videoOptions::FLIP_UPPER_RIGHT_DIAGONAL )
+	{
+		const guint prevWidth = width;
+		width = height;
+		height = prevWidth;
+	}
 	
 	const float framerate_num   = gst_discoverer_video_info_get_framerate_num(videoInfo);
 	const float framerate_denom = gst_discoverer_video_info_get_framerate_denom(videoInfo);


### PR DESCRIPTION
If you give `videoSource` a flip parameter that changes the aspect ratio (rotation 90 degrees or mirror along the diagonal) and don't specify any size, the output will have the same aspect ratio and size as the source video, though height and width should be swapped. This happens for video streams that are configured through `gstDecoder.cpp` (not CSI cameras).

This bug fix makes sure that the video is not scaled in any direction, unless height or width parameters are explicitly provided.