### PR TITLE
Add automatic flip method that rotates video based on video tags.

### DIFF
--- a/camera/gstCamera.cpp
+++ b/camera/gstCamera.cpp
@@ -133,6 +133,8 @@ bool gstCamera::buildLaunchStr()
 
 	if( mOptions.resource.protocol == "csi" )
 	{
+		if( mOptions.flipMethod == videoOptions::FLIP_AUTOMATIC || mOptions.flipMethod == videoOptions::FLIP_UNDEFINED )
+			mOptions.flipMethod = videoOptions::FLIP_NONE;
 	#if NV_TENSORRT_MAJOR > 4
 		// on newer JetPack's, it's common for CSI camera to need flipped
 		// so here we reverse FLIP_NONE with FLIP_ROTATE_180

--- a/codec/gstDecoder.cpp
+++ b/codec/gstDecoder.cpp
@@ -354,6 +354,39 @@ bool gstDecoder::discover()
 		return false;
 	}
 	
+	// Look at video tags and extract rotation
+	const GstTagList* tags = gst_discoverer_stream_info_get_tags(streamInfo);
+	if( tags ) {
+		// Extract tags
+		gchar* tagsStr = gst_tag_list_to_string(tags);
+		LogVerbose(LOG_GSTREAMER "gstDecoder -- tags: %s\n", tagsStr);
+		g_free(tagsStr);
+
+		// If flip method is not finalized, check for rotation tags in the video.
+		if( mOptions.flipMethod == videoOptions::FLIP_AUTOMATIC || mOptions.flipMethod == videoOptions::FLIP_UNDEFINED ) {
+			gchar* rotationTag;
+			const bool foundRotationTag = gst_tag_list_get_string(tags, "image-orientation", &rotationTag);
+			if (foundRotationTag) {
+				if( strcasecmp(rotationTag, "rotate-90") == 0 )
+					mOptions.flipMethod = videoOptions::FLIP_CLOCKWISE;
+				else if( strcasecmp(rotationTag, "rotate-180") == 0 )
+					mOptions.flipMethod = videoOptions::FLIP_ROTATE_180;
+				else if( strcasecmp(rotationTag, "rotate-270") == 0 )
+					mOptions.flipMethod = videoOptions::FLIP_COUNTERCLOCKWISE;
+				LogVerbose(LOG_GSTREAMER "gstDecoder -- rotation tag: %s\n", rotationTag);
+			} else {
+				LogVerbose(LOG_GSTREAMER "gstDecoder -- found no rotation tag\n");
+			}
+		}
+	} else {
+		LogVerbose(LOG_GSTREAMER "gstDecoder -- found no tags\n");
+	}
+
+	// If flip is still not set after looking at tags, default to FLIP_NONE
+	if( mOptions.flipMethod == videoOptions::FLIP_AUTOMATIC || mOptions.flipMethod == videoOptions::FLIP_UNDEFINED ) {
+		mOptions.flipMethod = videoOptions::FLIP_NONE;
+	}
+
 	// retrieve video resolution
 	guint width  = gst_discoverer_video_info_get_width(videoInfo);
 	guint height = gst_discoverer_video_info_get_height(videoInfo);
@@ -370,7 +403,7 @@ bool gstDecoder::discover()
 	const float framerate       = framerate_num / framerate_denom;
 
 	LogVerbose(LOG_GSTREAMER "gstDecoder -- discovered video resolution: %ux%u  (framerate %f Hz)\n", width, height, framerate);
-	
+
 	// disable re-scaling if the user's custom size matches the feed's
 	if( mCustomSize && mOptions.width == width && mOptions.height == height )
 		mCustomSize = false;

--- a/video/videoOptions.cpp
+++ b/video/videoOptions.cpp
@@ -38,7 +38,7 @@ videoOptions::videoOptions()
 	zeroCopy    = true;
 	ioType      = INPUT;
 	deviceType  = DEVICE_DEFAULT;
-	flipMethod  = FLIP_DEFAULT;
+	flipMethod  = FLIP_UNDEFINED;
 	codec       = CODEC_UNKNOWN;
 }
 
@@ -136,6 +136,9 @@ bool videoOptions::Parse( const char* URI, const commandLine& cmdLine, videoOpti
 	}
 	
 	flipMethod = videoOptions::FlipMethodFromStr(flipStr);
+
+	if( flipMethod == videoOptions::FLIP_UNDEFINED )
+		flipMethod = (type == INPUT) ? videoOptions::FLIP_INPUT_DEFAULT : videoOptions::FLIP_OUTPUT_DEFUALT;
 
 	// codec
 	const char* codecStr = (type == INPUT) ? cmdLine.GetString("input-codec")
@@ -284,6 +287,8 @@ const char* videoOptions::FlipMethodToStr( videoOptions::FlipMethod flip )
 		case FLIP_UPPER_RIGHT_DIAGONAL:	return "upper-right-diagonal";
 		case FLIP_VERTICAL:				return "vertical";
 		case FLIP_UPPER_LEFT_DIAGONAL:	return "upper-left-diagonal";
+		case FLIP_AUTOMATIC:            return "automatic";
+		case FLIP_UNDEFINED:            return "undefined";
 	}
 	return nullptr;
 }
@@ -293,9 +298,9 @@ const char* videoOptions::FlipMethodToStr( videoOptions::FlipMethod flip )
 videoOptions::FlipMethod videoOptions::FlipMethodFromStr( const char* str )
 {
 	if( !str )
-		return FLIP_DEFAULT;
+		return FLIP_UNDEFINED;
 
-	for( int n=0; n <= FLIP_UPPER_LEFT_DIAGONAL; n++ )
+	for( int n=0; n <= FLIP_UNDEFINED; n++ )
 	{
 		const FlipMethod value = (FlipMethod)n;
 
@@ -303,7 +308,7 @@ videoOptions::FlipMethod videoOptions::FlipMethodFromStr( const char* str )
 			return value;
 	}
 
-	return FLIP_DEFAULT;
+	return FLIP_UNDEFINED;
 }
 
 

--- a/video/videoOptions.h
+++ b/video/videoOptions.h
@@ -150,7 +150,10 @@ public:
 		FLIP_UPPER_RIGHT_DIAGONAL,	/**< Flip across upper right/lower left diagonal */
 		FLIP_VERTICAL,				/**< Flip vertically */
 		FLIP_UPPER_LEFT_DIAGONAL,	/**< Flip across upper left/lower right diagonal */
-		FLIP_DEFAULT = FLIP_NONE		/**< Default setting (none) */
+		FLIP_AUTOMATIC,             /**< Choose rotation based on video tag */
+		FLIP_UNDEFINED,
+		FLIP_INPUT_DEFAULT = FLIP_AUTOMATIC,	/**< Default for video input */
+		FLIP_OUTPUT_DEFUALT = FLIP_NONE			/**< Default for video output */
 	};
 
 	/**
@@ -168,6 +171,7 @@ public:
 	 *   - `vertical-flip`        (Flip vertically)
 	 *   - `upper-right-diagonal` (Flip across upper right/lower left diagonal)
 	 *   - `upper-left-diagonal`  (Flip across upper left/lower right diagonal)
+	 *   - `automatic`			  (Choose rotation based on video tag)
 	 */
 	FlipMethod flipMethod;
 


### PR DESCRIPTION
Add an `automatic` flip option that rotates video based on rotation tags in the video (that are very common in videos recorded by mobile phones). If there are no such tags, no flip is applied.

I made the `automatic` mode default, as it is the most natural behavior for videos with rotation tags, and behaves just like `none` (the previous default) for videos with no rotation tags. This choice is, however, debatable as it changes the default behavior for videos with rotation tags (into a more natural behavior).