### PR TITLE
Add option for setting latency parameter of rtspsrc

### DIFF
--- a/codec/gstDecoder.cpp
+++ b/codec/gstDecoder.cpp
@@ -525,7 +525,7 @@ bool gstDecoder::buildLaunchStr()
 	else if( uri.protocol == "rtsp" )
 	{
 		ss << "rtspsrc location=" << uri.string;
-		//ss << " latency=200 drop-on-latency=true";
+		ss << " latency=" << mOptions.rtspLatency;
 		ss << " ! queue ! ";
 		
 		if( mOptions.codec == videoOptions::CODEC_H264 )

--- a/video/videoOptions.cpp
+++ b/video/videoOptions.cpp
@@ -35,6 +35,7 @@ videoOptions::videoOptions()
 	bitRate     = 0;
 	numBuffers  = 4;
 	loop        = 0;
+	rtspLatency = 2000;
 	zeroCopy    = true;
 	ioType      = INPUT;
 	deviceType  = DEVICE_DEFAULT;
@@ -67,6 +68,7 @@ void videoOptions::Print( const char* prefix ) const
 	LogInfo("  -- zeroCopy:   %s\n", zeroCopy ? "true" : "false");	
 	LogInfo("  -- flipMethod: %s\n", FlipMethodToStr(flipMethod));
 	LogInfo("  -- loop:       %i\n", loop);
+	LogInfo("  -- rtspLatency %i\n", rtspLatency);
 	
 	LogInfo("------------------------------------------------\n");
 }
@@ -159,6 +161,9 @@ bool videoOptions::Parse( const char* URI, const commandLine& cmdLine, videoOpti
 		if( loop == -999 )
 			loop = cmdLine.GetInt("loop");
 	}
+
+	// RTSP latency
+	rtspLatency = cmdLine.GetUnsignedInt("input-rtsp-latency", rtspLatency);
 	
 	return true;
 }

--- a/video/videoOptions.h
+++ b/video/videoOptions.h
@@ -106,6 +106,12 @@ public:
 	int loop;
 
 	/**
+	 * Number of milliseconds of video to buffer for incoming RTSP streams (the default is 2000 ms).
+	 * This option can be set from the command line using `--input-rtsp-latency=N`
+	 */
+	int rtspLatency;
+
+	/**
 	 * Device interface types.
 	 */
 	enum DeviceType


### PR DESCRIPTION
Added option for setting RTSP latency of `videoSource`.

This makes RTSP streaming much more useful for real-time settings, as it can stream with near-zero lag when network conditions allow for it. And when the network conditions require it, you can use the buffer to avoid jitter.