### PR TITLE
Increase GstDiscoverer timeout to make it more robust

### DIFF
--- a/codec/gstDecoder.cpp
+++ b/codec/gstDecoder.cpp
@@ -320,7 +320,7 @@ bool gstDecoder::discover()
 
 	// create a new discovery interface
 	GError* err = NULL;
-	GstDiscoverer* discoverer = gst_discoverer_new(GST_SECOND, &err);
+	GstDiscoverer* discoverer = gst_discoverer_new(5 * GST_SECOND, &err);
 	
 	if( !discoverer )
 	{


### PR DESCRIPTION
When I try to open an RTSP stream it fails around 80 % of the times, because GstDiscoverer doesn't succeed getting stream info within the timeout. It even fails sometimes when opening a video file that is stored on the SD card in the Jetson Nano.

I increased the timeout from 1 to 5 seconds, which has resulted in 100 % success rate in my experiments, without increasing the discovery time when it works.