### PR TITLE
Fixed. Infinite recursive call. videoOptions::Parse()

### DIFF
--- a/video/videoOptions.cpp
+++ b/video/videoOptions.cpp
@@ -75,9 +75,11 @@ void videoOptions::Print( const char* prefix ) const
 
 
 // Parse
-bool videoOptions::Parse( const char* URI, const int argc, char** argv, videoOptions::IoType type )
+bool videoOptions::Parse( const char* URI, const int argc, char** argv, videoOptions::IoType type, const char* extraFlag )
 {
-	return Parse(URI, argc, argv, type);
+	commandLine cmdLine(argc, argv, extraFlag);
+
+	return Parse(URI, cmdLine, type);
 }
 
 

--- a/video/videoOptions.h
+++ b/video/videoOptions.h
@@ -214,7 +214,7 @@ public:
 	/**
 	 * @internal Parse the video resource URI and options.
 	 */
-	bool Parse( const char* URI, const int argc, char** argv, IoType ioType);
+	bool Parse( const char* URI, const int argc, char** argv, IoType ioType, const char* extraFlag=NULL);
 
 	/**
 	 * @internal Parse the video resource URI and options.


### PR DESCRIPTION
The function 'videoOptions::Parse( URI, argc, argv, type )' has infinite recursive call.

I changed it to call the function 'videoOptions::Parse( URI, cmdLine, type )'.
