### PR TITLE
added unitialization of the buffers for closing

### DIFF
--- a/camera/v4l2Camera.cpp
+++ b/camera/v4l2Camera.cpp
@@ -387,6 +387,18 @@ bool v4l2Camera::init()
 	return true;
 }
 
+// uninitDevice
+bool v4l2Camera::uninitDevice()
+{
+	// uninitialize buffers, otherwise opening the device again will not work properly!
+	for (int i = 0; i < mBufferCountMMap; ++i) {
+		if (-1 == munmap(mBuffersMMap[i].ptr, mBuffersMMap[i].buf.length))
+            printf("v4l2 -- could not unmap buffers properly\n");
+			return false;
+	}
+	free(mBuffersMMap);
+	return true;
+}
 
 // Open
 bool v4l2Camera::Open()
@@ -411,6 +423,11 @@ bool v4l2Camera::Open()
 // Close
 bool v4l2Camera::Close()
 {
+	// unitialize the buffers before closing the device
+	if (!uninitDevice()) {
+		printf("v4l2 -- could not uninitialize device\n");
+	}
+	
 	// stop streaming
 	enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 

--- a/camera/v4l2Camera.h
+++ b/camera/v4l2Camera.h
@@ -99,6 +99,8 @@ private:
 	bool initUserPtr();
 	bool initMMap();
 
+	bool uninitDevice();
+
 	int 	    mFD;
 	int	    mRequestFormat;
 	uint32_t mRequestWidth;


### PR DESCRIPTION
I stumbled across this while trying to run a google benchmark on the capture function. When I compared the v4l2Camera to the example code of v4l I noticed it lacked the memory unmap.