### PR TITLE
Change video decoder from omx*dec to nvv4l2decoder.

### DIFF
--- a/codec/gstDecoder.cpp
+++ b/codec/gstDecoder.cpp
@@ -558,17 +558,23 @@ bool gstDecoder::buildLaunchStr()
 
 #if GST_CHECK_VERSION(1,0,0)
 	if( mOptions.codec == videoOptions::CODEC_H264 )
-		ss << "omxh264dec ! ";
+		// ss << "omxh264dec ! ";
+		ss << "nvv4l2decoder ! ";
 	else if( mOptions.codec == videoOptions::CODEC_H265 )
-		ss << "omxh265dec ! ";
+		// ss << "omxh265dec ! ";
+		ss << "nvv4l2decoder ! ";
 	else if( mOptions.codec == videoOptions::CODEC_VP8 )
-		ss << "omxvp8dec ! ";
+		// ss << "omxvp8dec ! ";
+		ss << "nvv4l2decoder ! ";
 	else if( mOptions.codec == videoOptions::CODEC_VP9 )
-		ss << "omxvp9dec ! ";
+		// ss << "omxvp9dec ! ";
+		ss << "nvv4l2decoder ! ";
 	else if( mOptions.codec == videoOptions::CODEC_MPEG2 )
-		ss << "omxmpeg2videodec ! ";
+		// ss << "omxmpeg2videodec ! ";
+		ss << "nvv4l2decoder ! ";
 	else if( mOptions.codec == videoOptions::CODEC_MPEG4 )
-		ss << "omxmpeg4videodec ! ";
+		// ss << "omxmpeg4videodec ! ";
+		ss << "nvv4l2decoder ! ";
 	else if( mOptions.codec == videoOptions::CODEC_MJPEG )
 		ss << "nvjpegdec ! ";
 #else
@@ -600,8 +606,6 @@ bool gstDecoder::buildLaunchStr()
 		return false;
 	}
 
-	// resize if requested
-	if( mCustomSize || mOptions.flipMethod != videoOptions::FLIP_NONE )
 	{
 		ss << "nvvidconv";
 
@@ -610,14 +614,11 @@ bool gstDecoder::buildLaunchStr()
 
 		ss << " ! video/x-raw";
 
-		if( mOptions.width != 0 && mOptions.height != 0 )
+		// resize if requested
+		if( mCustomSize && mOptions.width != 0 && mOptions.height != 0 )
 			ss << ", width=(int)" << mOptions.width << ", height=(int)" << mOptions.height << ", format=(string)NV12";
 
-		ss <<" ! ";
-	}
-	else
-	{
-		ss << "video/x-raw ! ";
+		ss << " ! ";
 	}
 
 	// rate-limit if requested


### PR DESCRIPTION
For some video files, the video shrinks vertically when decoded.
Near the bottom few lines are green, black, or a duplicate of the bottom line.
For example, this phenomenon may occur in video files converted by FFMpeg or generated by Davinci Resolve.
Therefore, I changed video decoder from omg*dec to nvv4l2decoder.

Just me?
My environment: JetPack 4.5.1

- using omxh264dec
![jetson-utils_omxh264dec](https://user-images.githubusercontent.com/22055372/130732617-d125654a-a884-4563-a754-abb47f6c8f22.jpg)

- using nvv4l2decoder
![jetson-utils_nvv4l2decoder](https://user-images.githubusercontent.com/22055372/130732634-383c2e2f-5f74-4404-85b8-88e82976a1a0.jpg)
