### PR TITLE
More selective frame rate.

### DIFF
--- a/camera/gstCamera.h
+++ b/camera/gstCamera.h
@@ -216,7 +216,7 @@ private:
 	
 	bool matchCaps( GstCaps* caps );
 	bool printCaps( GstCaps* caps );
-	bool parseCaps( GstStructure* caps, videoOptions::Codec* codec, imageFormat* format, uint32_t* width, uint32_t* height, float* frameRate );
+	bool parseCaps( GstStructure* caps, videoOptions::Codec* codec, imageFormat* format, uint32_t* width, uint32_t* height, float* frameRate, int* frameRateNum, int* frameRateDenom );
 	
 	_GstBus*     mBus;
 	_GstAppSink* mAppSink;

--- a/video/videoOptions.cpp
+++ b/video/videoOptions.cpp
@@ -32,6 +32,8 @@ videoOptions::videoOptions()
 	width 	  = 0;
 	height 	  = 0;
 	frameRate   = 0;
+	frameRateNum = 0;
+	frameRateDenom = 0;
 	bitRate     = 0;
 	numBuffers  = 4;
 	loop        = 0;
@@ -62,7 +64,7 @@ void videoOptions::Print( const char* prefix ) const
 	LogInfo("  -- codec:      %s\n", CodecToStr(codec));
 	LogInfo("  -- width:      %u\n", width);
 	LogInfo("  -- height:     %u\n", height);
-	LogInfo("  -- frameRate:  %f\n", frameRate);
+	LogInfo("  -- frameRate:  %.2f (%d/%d)\n", frameRate, frameRateNum, frameRateDenom);
 	LogInfo("  -- bitRate:    %u\n", bitRate);
 	LogInfo("  -- numBuffers: %u\n", numBuffers);
 	LogInfo("  -- zeroCopy:   %s\n", zeroCopy ? "true" : "false");	
@@ -125,6 +127,11 @@ bool videoOptions::Parse( const char* URI, const commandLine& cmdLine, videoOpti
 
 	if( frameRate == 0 )
 		frameRate = cmdLine.GetFloat("framerate");
+
+	if (frameRate != 0) {
+		frameRateDenom = 100;
+		frameRateNum = int(frameRate * frameRateDenom);
+	}
 
 	// flip-method
 	const char* flipStr = (type == INPUT) ? cmdLine.GetString("input-flip")

--- a/video/videoOptions.h
+++ b/video/videoOptions.h
@@ -68,6 +68,8 @@ public:
 	 * for input and output streams, respectively. The `--framerate=N` option sets it for both.
 	 */
 	float frameRate;
+	int frameRateNum;
+	int frameRateDenom;
 	
 	/**
 	 * The encoding bitrate for compressed streams (only applies to video codecs like H264/H265).


### PR DESCRIPTION
In cases where the fastest frame rate is not always required, the processing time of discarded frames is wasteful.
In that case, it is better to be able to set a more suitable frame rate.
That's why I made it possible to specify the frame rate as a real number with a command line option.
If there is no matching value in the list of configurable frame rates, select the closest value.
