### PR TITLE
Fixed bug where background was incorrectly reset given multiple strings

### DIFF
--- a/cuda/cudaFont.cu
+++ b/cuda/cudaFont.cu
@@ -476,7 +476,7 @@ bool cudaFont::OverlayText( void* image, imageFormat format, uint32_t width, uin
 
 		// reset the background rect if needed
 		if( has_bg )
-			mRectsCPU[mRectIndex] = make_float4(width, height, 0, 0);
+			mRectsCPU[mRectIndex+numRects] = make_float4(width, height, 0, 0);
 
 		// make a glyph command for each character
 		for( uint32_t n=0; n < numChars; n++ )


### PR DESCRIPTION
There is a bug in `cudaFonts.cu:479` that causes incorrect backgrounds to be drawn when multiple strings are given to `cudaFont::OverlayText`. The current rectangle from `mRectsCPU` is not correctly indexed. Instead, always the first rectangle in `mRectsCPU` is indexed and reset. Incrementing with `numRects` fixes this issue. 

Code to make the issue more clear:
```
std::vector< std::pair< std::string, int2 > > labels;
labels.push_back(std::pair<std::string, int2>("Box One", {1100, 700}));
labels.push_back(std::pair<std::string, int2>("Box Two", {1150, 900}));
labels.push_back(std::pair<std::string, int2>("Box Three", {1450, 800}));
font->OverlayText(output, format, width, height, labels, make_float4(255,255,255,255), make_float4(0, 0, 0, 255), 20);
```

Two images showing the result before and after the fix:

### before
![chess_before_fix](https://user-images.githubusercontent.com/5947757/147751553-8e289108-656f-4300-bac3-3f86e237eb85.png)

### after
![chess_after_fix](https://user-images.githubusercontent.com/5947757/147751568-302cae29-773b-4f76-8e69-420fb3bb82b8.png)

