### PR TITLE
Add timestamp and raw image capture support for gstCamera

### DIFF
--- a/camera/gstCamera.cpp
+++ b/camera/gstCamera.cpp
@@ -46,6 +46,7 @@ gstCamera::gstCamera( const videoOptions& options ) : videoSource(options)
 	mFormatYUV = IMAGE_UNKNOWN;
 	
 	mBufferManager = new gstBufferManager(&mOptions);
+	mLastTimestamp = 0;
 }
 
 
@@ -675,6 +676,9 @@ bool gstCamera::Capture( void** output, imageFormat format, uint64_t timeout )
 		LogError(LOG_GSTREAMER "gstDecoder -- failed to retrieve next image buffer\n");
 		return false;
 	}
+
+	mLastTimestamp = mBufferManager->GetLastTimestamp();
+	// LogInfo(LOG_GSTREAMER "GetLastTimestamp -- %f sec\n", mLastTimestamp / 1.e+9);
 	
 	return true;
 }

--- a/camera/gstCamera.cpp
+++ b/camera/gstCamera.cpp
@@ -46,7 +46,6 @@ gstCamera::gstCamera( const videoOptions& options ) : videoSource(options)
 	mFormatYUV = IMAGE_UNKNOWN;
 	
 	mBufferManager = new gstBufferManager(&mOptions);
-	mLastTimestamp = 0;
 }
 
 
@@ -678,8 +677,8 @@ bool gstCamera::Capture( void** output, imageFormat format, uint64_t timeout )
 	}
 
 	mLastTimestamp = mBufferManager->GetLastTimestamp();
-	// LogInfo(LOG_GSTREAMER "GetLastTimestamp -- %f sec\n", mLastTimestamp / 1.e+9);
-	
+	mRawFormat = mBufferManager->GetRawFormat();
+
 	return true;
 }
 

--- a/camera/gstCamera.h
+++ b/camera/gstCamera.h
@@ -179,6 +179,12 @@ public:
 	bool CaptureRGBA( float** image, uint64_t timeout=UINT64_MAX, bool zeroCopy=false );
 
 	/**
+	 * Set whether converted RGB(A) images should use ZeroCopy buffer allocation.
+	 * Has no effect after the first image (in RGB(A) format) was captured.
+	 */
+	void SetZeroCopy(bool zeroCopy)     { mOptions.zeroCopy = zeroCopy; }
+
+	/**
 	 * Return the interface type (gstCamera::Type)
 	 */
 	virtual inline uint32_t GetType() const		{ return Type; }

--- a/camera/gstCamera.h
+++ b/camera/gstCamera.h
@@ -179,11 +179,6 @@ public:
 	bool CaptureRGBA( float** image, uint64_t timeout=UINT64_MAX, bool zeroCopy=false );
 
 	/**
-	 * Get timestamp of the latest captured frame.
-	 */
-	uint64_t GetLastTimestamp() const { return mLastTimestamp; }
-
-	/**
 	 * Return the interface type (gstCamera::Type)
 	 */
 	virtual inline uint32_t GetType() const		{ return Type; }
@@ -229,7 +224,6 @@ private:
 	imageFormat  mFormatYUV;
 	
 	gstBufferManager* mBufferManager;
-	uint64_t          mLastTimestamp;  /**< Timestamp of the latest captured (i.e. dequeued) frame */
 };
 
 #endif

--- a/camera/gstCamera.h
+++ b/camera/gstCamera.h
@@ -179,6 +179,11 @@ public:
 	bool CaptureRGBA( float** image, uint64_t timeout=UINT64_MAX, bool zeroCopy=false );
 
 	/**
+	 * Get timestamp of the latest captured frame.
+	 */
+	uint64_t GetLastTimestamp() const { return mLastTimestamp; }
+
+	/**
 	 * Return the interface type (gstCamera::Type)
 	 */
 	virtual inline uint32_t GetType() const		{ return Type; }
@@ -224,6 +229,7 @@ private:
 	imageFormat  mFormatYUV;
 	
 	gstBufferManager* mBufferManager;
+	uint64_t          mLastTimestamp;  /**< Timestamp of the latest captured (i.e. dequeued) frame */
 };
 
 #endif

--- a/codec/gstBufferManager.cpp
+++ b/codec/gstBufferManager.cpp
@@ -268,6 +268,12 @@ bool gstBufferManager::Enqueue( GstBuffer* gstBuffer, GstCaps* gstCaps )
 			return false;
 		}
 
+		if (GST_BUFFER_DTS_IS_VALID(gstBuffer) || GST_BUFFER_PTS_IS_VALID(gstBuffer))
+		{
+			timestamp = GST_BUFFER_DTS_OR_PTS(gstBuffer);
+		}
+		// LogInfo("Timestams: %lu, %lu, %lu, %d, %d, %d, %lu\n", GST_BUFFER_DTS(gstBuffer), GST_BUFFER_PTS(gstBuffer), GST_BUFFER_DURATION(gstBuffer), GST_BUFFER_DTS_IS_VALID(gstBuffer), GST_BUFFER_PTS_IS_VALID(gstBuffer), GST_BUFFER_DURATION_IS_VALID(gstBuffer), timestamp);
+
 		memcpy(nextTimestamp, (void*)&timestamp, timestamp_size);
 		mTimestamps.Next(RingBuffer::Write);
 

--- a/codec/gstBufferManager.h
+++ b/codec/gstBufferManager.h
@@ -89,6 +89,11 @@ public:
 	uint64_t GetLastTimestamp() const { return mLastTimestamp; }
 
 	/**
+	 * Get raw image format.
+  	 */
+	inline imageFormat GetRawFormat() const { return mFormatYUV; }
+
+	/**
 	 * Get the total number of frames that have been recieved.
 	 */
 	inline uint64_t GetFrameCount() const	{ return mFrameCount; }
@@ -97,14 +102,14 @@ protected:
 
 	imageFormat   mFormatYUV;  /**< The YUV colorspace format coming from appsink (typically NV12 or YUY2) */
 	RingBuffer    mBufferYUV;  /**< Ringbuffer of CPU-based YUV frames (non-NVMM) that come from appsink */
-	RingBuffer    mTimestamps;  /**< Ringbuffer of timestamps that come from appsink */
+	RingBuffer    mTimestamps; /**< Ringbuffer of timestamps that come from appsink */
 	RingBuffer    mBufferRGB;  /**< Ringbuffer of frames that have been converted to RGB colorspace */
 	uint64_t      mLastTimestamp;  /**< Timestamp of the latest dequeued frame */
-	Event	    mWaitEvent;  /**< Event that gets triggered when a new frame is recieved */
+	Event	      mWaitEvent;  /**< Event that gets triggered when a new frame is recieved */
 	
 	videoOptions* mOptions;    /**< Options of the gstDecoder / gstCamera object */			
-	uint64_t	    mFrameCount; /**< Total number of frames that have been recieved */
-	bool 	    mNvmmUsed;	  /**< Is NVMM memory actually used by the stream? */
+	uint64_t	  mFrameCount; /**< Total number of frames that have been recieved */
+	bool 	      mNvmmUsed;   /**< Is NVMM memory actually used by the stream? */
 	
 #ifdef ENABLE_NVMM
 	Mutex  mNvmmMutex;

--- a/codec/gstBufferManager.h
+++ b/codec/gstBufferManager.h
@@ -84,6 +84,11 @@ public:
 	bool Dequeue( void** output, imageFormat format, uint64_t timeout=UINT64_MAX );
 
 	/**
+	 * Get timestamp of the latest dequeued frame.
+	 */
+	uint64_t GetLastTimestamp() const { return mLastTimestamp; }
+
+	/**
 	 * Get the total number of frames that have been recieved.
 	 */
 	inline uint64_t GetFrameCount() const	{ return mFrameCount; }
@@ -92,7 +97,9 @@ protected:
 
 	imageFormat   mFormatYUV;  /**< The YUV colorspace format coming from appsink (typically NV12 or YUY2) */
 	RingBuffer    mBufferYUV;  /**< Ringbuffer of CPU-based YUV frames (non-NVMM) that come from appsink */
+	RingBuffer    mTimestamps;  /**< Ringbuffer of timestamps that come from appsink */
 	RingBuffer    mBufferRGB;  /**< Ringbuffer of frames that have been converted to RGB colorspace */
+	uint64_t      mLastTimestamp;  /**< Timestamp of the latest dequeued frame */
 	Event	    mWaitEvent;  /**< Event that gets triggered when a new frame is recieved */
 	
 	videoOptions* mOptions;    /**< Options of the gstDecoder / gstCamera object */			

--- a/python/bindings/PyCUDA.h
+++ b/python/bindings/PyCUDA.h
@@ -63,7 +63,7 @@ PyCudaMemory* PyCUDA_GetMemory( PyObject* object );
 PyCudaImage* PyCUDA_GetImage( PyObject* object );
 
 // retrieve from capsule
-void* PyCUDA_GetImage( PyObject* object, int* width, int* height, imageFormat* format );
+void* PyCUDA_GetImage( PyObject* object, int* width, int* height, imageFormat* format, uint64_t* timestamp=NULL );
 
 // Register functions
 PyMethodDef* PyCUDA_RegisterFunctions();

--- a/python/bindings/PyCUDA.h
+++ b/python/bindings/PyCUDA.h
@@ -39,6 +39,7 @@ typedef struct {
 typedef struct {
 	PyCudaMemory base;
 	imageFormat format;
+	uint64_t    timestamp;
 	uint32_t    width;
 	uint32_t    height;
 	Py_ssize_t  shape[3];
@@ -50,7 +51,7 @@ PyObject* PyCUDA_RegisterMemory( void* ptr, size_t size, bool mapped=false, bool
 //PyObject* PyCUDA_RegisterMappedMemory( void* ptr, size_t size, bool freeOnDelete=true );
 
 // Create image objects
-PyObject* PyCUDA_RegisterImage( void* ptr, uint32_t width, uint32_t height, imageFormat format, bool mapped=false, bool freeOnDelete=true );
+PyObject* PyCUDA_RegisterImage( void* ptr, uint32_t width, uint32_t height, imageFormat format, uint64_t timestamp=0, bool mapped=false, bool freeOnDelete=true );
 //PyObject* PyCUDA_RegisterMappedImage( void* ptr, uint32_t width, uint32_t height, imageFormat format, bool freeOnDelete=true );
 
 // type checks

--- a/python/bindings/PyCamera.cpp
+++ b/python/bindings/PyCamera.cpp
@@ -149,8 +149,8 @@ static PyObject* PyCamera_Close( PyCamera_Object* self )
 }
 
 
-// CaptureRGBA
-static PyObject* PyCamera_CaptureRGBA( PyCamera_Object* self, PyObject* args, PyObject* kwds )
+// Capture
+static PyObject* PyCamera_Capture( PyCamera_Object* self, PyObject* args, PyObject* kwds, const char* default_format="raw" )
 {
 	if( !self || !self->camera )
 	{
@@ -159,14 +159,15 @@ static PyObject* PyCamera_CaptureRGBA( PyCamera_Object* self, PyObject* args, Py
 	}
 
 	// parse arguments
+	const char* pyFormat = default_format;
 	int pyTimeout  = -1;
-	int pyZeroCopy = 0;
+	int pyZeroCopy = 1;
 
-	static char* kwlist[] = {"timeout", "zeroCopy", NULL};
+	static char* kwlist[] = {"format", "timeout", "zeroCopy", NULL};
 
-	if( !PyArg_ParseTupleAndKeywords(args, kwds, "|ii", kwlist, &pyTimeout, &pyZeroCopy))
+	if( !PyArg_ParseTupleAndKeywords(args, kwds, "|sii", kwlist, &pyFormat, &pyTimeout, &pyZeroCopy))
 	{
-		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "gstCamera.CaptureRGBA() failed to parse args tuple");
+		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "gstCamera.Capture() failed to parse args tuple");
 		return NULL;
 	}
 
@@ -176,20 +177,25 @@ static PyObject* PyCamera_CaptureRGBA( PyCamera_Object* self, PyObject* args, Py
 	if( pyTimeout >= 0 )
 		timeout = pyTimeout;
 
+	// convert format string to enum
+	const imageFormat format = imageFormatFromStr(pyFormat);
+
 	// convert int zeroCopy to boolean
 	const bool zeroCopy = pyZeroCopy <= 0 ? false : true;
 
-	// capture RGBA
-	float* ptr = NULL;
+	// capture image
+	void* ptr = NULL;
 
-	if( !self->camera->CaptureRGBA(&ptr, timeout, zeroCopy) )
+	self->camera->SetZeroCopy(zeroCopy);  // takes effect on the first call only
+
+	if( !self->camera->Capture(&ptr, format, timeout) )
 	{
-		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "gstCamera failed to CaptureRGBA()");
+		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "gstCamera failed to Capture()");
 		return NULL;
 	}
 
 	// register memory capsule (gstCamera will free the underlying memory when camera is deleted)
-	PyObject* capsule = PyCUDA_RegisterImage(ptr, self->camera->GetWidth(), self->camera->GetHeight(), IMAGE_RGBA32F, self->camera->GetLastTimestamp(), zeroCopy, false);
+	PyObject* capsule = PyCUDA_RegisterImage(ptr, self->camera->GetWidth(), self->camera->GetHeight(), format == IMAGE_UNKNOWN ? self->camera->GetRawFormat() : format, self->camera->GetLastTimestamp(), self->camera->GetOptions().zeroCopy, false);
 
 	if( !capsule )
 		return NULL;
@@ -207,6 +213,72 @@ static PyObject* PyCamera_CaptureRGBA( PyCamera_Object* self, PyObject* args, Py
 
 	return tuple;
 }
+
+
+static PyObject* PyCamera_CaptureRGBA( PyCamera_Object* self, PyObject* args, PyObject* kwds )
+{
+	return PyCamera_Capture(self, args, kwds, "rgba32f");
+}
+
+
+//// CaptureRGBA
+//static PyObject* PyCamera_CaptureRGBA( PyCamera_Object* self, PyObject* args, PyObject* kwds )
+//{
+//	if( !self || !self->camera )
+//	{
+//		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "gstCamera invalid object instance");
+//		return NULL;
+//	}
+//
+//	// parse arguments
+//	int pyTimeout  = -1;
+//	int pyZeroCopy = 1;
+//
+//	static char* kwlist[] = {"timeout", "zeroCopy", NULL};
+//
+//	if( !PyArg_ParseTupleAndKeywords(args, kwds, "|ii", kwlist, &pyTimeout, &pyZeroCopy))
+//	{
+//		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "gstCamera.CaptureRGBA() failed to parse args tuple");
+//		return NULL;
+//	}
+//
+//	// convert signed timeout to unsigned long
+//	uint64_t timeout = UINT64_MAX;
+//
+//	if( pyTimeout >= 0 )
+//		timeout = pyTimeout;
+//
+//	// convert int zeroCopy to boolean
+//	const bool zeroCopy = pyZeroCopy <= 0 ? false : true;
+//
+//	// capture RGBA
+//	float* ptr = NULL;
+//
+//	if( !self->camera->CaptureRGBA(&ptr, timeout, zeroCopy) )
+//	{
+//		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "gstCamera failed to CaptureRGBA()");
+//		return NULL;
+//	}
+//
+//	// register memory capsule (gstCamera will free the underlying memory when camera is deleted)
+//	PyObject* capsule = PyCUDA_RegisterImage(ptr, self->camera->GetWidth(), self->camera->GetHeight(), IMAGE_RGBA32F, self->camera->GetLastTimestamp(), zeroCopy, false);
+//
+//	if( !capsule )
+//		return NULL;
+//
+//	// create dimension objects
+//	PyObject* pyWidth  = PYLONG_FROM_LONG(self->camera->GetWidth());
+//	PyObject* pyHeight = PYLONG_FROM_LONG(self->camera->GetHeight());
+//
+//	// return tuple
+//	PyObject* tuple = PyTuple_Pack(3, capsule, pyWidth, pyHeight);
+//
+//	Py_DECREF(capsule);
+//	Py_DECREF(pyWidth);
+//	Py_DECREF(pyHeight);
+//
+//	return tuple;
+//}
 
 
 // GetWidth()
@@ -246,6 +318,7 @@ static PyMethodDef pyCamera_Methods[] =
 {
 	{ "Open", (PyCFunction)PyCamera_Open, METH_NOARGS, "Open the camera for streaming frames"},
 	{ "Close", (PyCFunction)PyCamera_Close, METH_NOARGS, "Stop streaming camera frames"},
+	{ "Capture", (PyCFunction)PyCamera_Capture, METH_VARARGS|METH_KEYWORDS, "Capture a camera frame (in raw format by default)"},
 	{ "CaptureRGBA", (PyCFunction)PyCamera_CaptureRGBA, METH_VARARGS|METH_KEYWORDS, "Capture a camera frame and convert it to float4 RGBA"},
 	{ "GetWidth", (PyCFunction)PyCamera_GetWidth, METH_NOARGS, "Return the width of the camera (in pixels)"},
 	{ "GetHeight", (PyCFunction)PyCamera_GetHeight, METH_NOARGS, "Return the height of the camera (in pixels)"},

--- a/python/bindings/PyCamera.cpp
+++ b/python/bindings/PyCamera.cpp
@@ -189,7 +189,7 @@ static PyObject* PyCamera_CaptureRGBA( PyCamera_Object* self, PyObject* args, Py
 	}
 
 	// register memory capsule (gstCamera will free the underlying memory when camera is deleted)
-	PyObject* capsule = PyCUDA_RegisterImage(ptr, self->camera->GetWidth(), self->camera->GetHeight(), IMAGE_RGBA32F, zeroCopy, false);
+	PyObject* capsule = PyCUDA_RegisterImage(ptr, self->camera->GetWidth(), self->camera->GetHeight(), IMAGE_RGBA32F, self->camera->GetLastTimestamp(), zeroCopy, false);
 
 	if( !capsule )
 		return NULL;

--- a/python/bindings/PyImageIO.cpp
+++ b/python/bindings/PyImageIO.cpp
@@ -31,9 +31,10 @@ PyObject* PyImageIO_Load( PyObject* self, PyObject* args, PyObject* kwds )
 {
 	const char* filename  = NULL;
 	const char* formatStr = "rgb8";
-	static char* kwlist[] = {"filename", "format", NULL};
+	static char* kwlist[] = {"filename", "format", "timestamp", NULL};
+	long long timestamp = 0;
 
-	if( !PyArg_ParseTupleAndKeywords(args, kwds, "s|s", kwlist, &filename, &formatStr))
+	if( !PyArg_ParseTupleAndKeywords(args, kwds, "s|sL", kwlist, &filename, &formatStr, &timestamp))
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "loadImage() failed to parse filename argument");
 		return NULL;
@@ -44,6 +45,12 @@ PyObject* PyImageIO_Load( PyObject* self, PyObject* args, PyObject* kwds )
 	if( format == IMAGE_UNKNOWN )
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "loadImage() invalid format string");
+		return NULL;
+	}
+
+	if( timestamp < 0 )
+	{
+		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "loadImage() timestamp cannot be negative");
 		return NULL;
 	}
 
@@ -58,7 +65,7 @@ PyObject* PyImageIO_Load( PyObject* self, PyObject* args, PyObject* kwds )
 		return NULL;
 	}
 		
-	return PyCUDA_RegisterImage(imgPtr, width, height, format, 0, true);
+	return PyCUDA_RegisterImage(imgPtr, width, height, format, timestamp, true);
 }
 
 
@@ -67,9 +74,10 @@ PyObject* PyImageIO_LoadRGBA( PyObject* self, PyObject* args, PyObject* kwds )
 {
 	const char* filename  = NULL;
 	const char* formatStr = "rgba32f";
-	static char* kwlist[] = {"filename", "format", NULL};
+	static char* kwlist[] = {"filename", "format", "timestamp", NULL};
+	long long timestamp = 0;
 
-	if( !PyArg_ParseTupleAndKeywords(args, kwds, "s|s", kwlist, &filename, &formatStr))
+	if( !PyArg_ParseTupleAndKeywords(args, kwds, "s|sL", kwlist, &filename, &formatStr, &timestamp))
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "loadImageRGBA() failed to parse filename argument");
 		return NULL;
@@ -80,6 +88,12 @@ PyObject* PyImageIO_LoadRGBA( PyObject* self, PyObject* args, PyObject* kwds )
 	if( format == IMAGE_UNKNOWN )
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "loadImageRGBA() invalid format string");
+		return NULL;
+	}
+
+	if( timestamp < 0 )
+	{
+		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "loadImageRGBA() timestamp cannot be negative");
 		return NULL;
 	}
 
@@ -95,7 +109,7 @@ PyObject* PyImageIO_LoadRGBA( PyObject* self, PyObject* args, PyObject* kwds )
 	}
 		
 	// register memory container
-	PyObject* capsule = PyCUDA_RegisterImage(imgPtr, width, height, format, 0, true);
+	PyObject* capsule = PyCUDA_RegisterImage(imgPtr, width, height, format, timestamp, true);
 
 	if( !capsule )
 		return NULL;

--- a/python/bindings/PyImageIO.cpp
+++ b/python/bindings/PyImageIO.cpp
@@ -58,7 +58,7 @@ PyObject* PyImageIO_Load( PyObject* self, PyObject* args, PyObject* kwds )
 		return NULL;
 	}
 		
-	return PyCUDA_RegisterImage(imgPtr, width, height, format, true);
+	return PyCUDA_RegisterImage(imgPtr, width, height, format, 0, true);
 }
 
 
@@ -95,7 +95,7 @@ PyObject* PyImageIO_LoadRGBA( PyObject* self, PyObject* args, PyObject* kwds )
 	}
 		
 	// register memory container
-	PyObject* capsule = PyCUDA_RegisterImage(imgPtr, width, height, format, true);
+	PyObject* capsule = PyCUDA_RegisterImage(imgPtr, width, height, format, 0, true);
 
 	if( !capsule )
 		return NULL;

--- a/python/bindings/PyNumpy.cpp
+++ b/python/bindings/PyNumpy.cpp
@@ -150,9 +150,10 @@ PyObject* PyNumpy_ToCUDA( PyObject* self, PyObject* args, PyObject* kwds )
 	PyObject* object = NULL;
 
 	int pyBGR=0;
-	static char* kwlist[] = {"array", "isBGR", NULL};
+	static char* kwlist[] = {"array", "isBGR", "timestamp", NULL};
+	long long timestamp = 0;
 
-	if( !PyArg_ParseTupleAndKeywords(args, kwds, "O|i", kwlist, &object, &pyBGR) )
+	if( !PyArg_ParseTupleAndKeywords(args, kwds, "O|iL", kwlist, &object, &pyBGR, &timestamp) )
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "cudaFromNumpy() failed to parse array argument");
 		return NULL;
@@ -161,6 +162,12 @@ PyObject* PyNumpy_ToCUDA( PyObject* self, PyObject* args, PyObject* kwds )
 	if( !PyArray_Check(object) )
 	{
 		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "Object passed to cudaFromNumpy() wasn't a numpy ndarray");
+		return NULL;
+	}
+
+	if( timestamp < 0 )
+	{
+		PyErr_SetString(PyExc_Exception, LOG_PY_UTILS "cudaFromNumpy() timestamp cannot be negative");
 		return NULL;
 	}
 
@@ -269,7 +276,7 @@ PyObject* PyNumpy_ToCUDA( PyObject* self, PyObject* args, PyObject* kwds )
 	PyObject* capsule = NULL;
 
 	if( format != IMAGE_UNKNOWN )	
-		capsule = PyCUDA_RegisterImage(gpuPtr, dims[1], dims[0], format, 0, true);
+		capsule = PyCUDA_RegisterImage(gpuPtr, dims[1], dims[0], format, timestamp, true);
 	else
 		capsule = PyCUDA_RegisterMemory(gpuPtr, size, true);
 

--- a/python/bindings/PyNumpy.cpp
+++ b/python/bindings/PyNumpy.cpp
@@ -96,12 +96,24 @@ PyObject* PyNumpy_FromCUDA( PyObject* self, PyObject* args, PyObject* kwds )
 	}
 	else
 	{
-		src    = img->base.ptr;
-		mapped = img->base.mapped;
-		width  = img->width;
-		height = img->height;
-		depth  = imageFormatChannels(img->format);
-		type   = PyNumpy_ConvertFormat(img->format);
+		if ( imageFormatIsYUV(img->format) )
+		{
+			src    = img->base.ptr;
+			mapped = img->base.mapped;
+			width  = 1;
+			height = 1;
+			depth  = img->base.size;
+			type   = PyNumpy_ConvertFormat(img->format);
+		}
+		else
+		{
+			src    = img->base.ptr;
+			mapped = img->base.mapped;
+			width  = img->width;
+			height = img->height;
+			depth  = imageFormatChannels(img->format);
+			type   = PyNumpy_ConvertFormat(img->format);
+		}
 	}
 	
 	if( !mapped )   // TODO  support GPU-only memory
@@ -257,7 +269,7 @@ PyObject* PyNumpy_ToCUDA( PyObject* self, PyObject* args, PyObject* kwds )
 	PyObject* capsule = NULL;
 
 	if( format != IMAGE_UNKNOWN )	
-		capsule = PyCUDA_RegisterImage(gpuPtr, dims[1], dims[0], format, true);
+		capsule = PyCUDA_RegisterImage(gpuPtr, dims[1], dims[0], format, 0, true);
 	else
 		capsule = PyCUDA_RegisterMemory(gpuPtr, size, true);
 

--- a/python/bindings/PyUtils.h
+++ b/python/bindings/PyUtils.h
@@ -52,6 +52,10 @@
 	#define PYLONG_FROM_UNSIGNED_LONG(x)	PyLong_FromUnsignedLong(x)
 	#endif
 
+	#ifndef PYLONG_FROM_UNSIGNED_LONG_LONG
+	#define PYLONG_FROM_UNSIGNED_LONG_LONG(x)	PyLong_FromUnsignedLongLong(x)
+	#endif
+
 	#ifndef PYSTRING_FROM_STRING
 	#define PYSTRING_FROM_STRING			PyUnicode_FromString
 	#endif
@@ -77,6 +81,10 @@
 
 	#ifndef PYLONG_FROM_UNSIGNED_LONG
 	#define PYLONG_FROM_UNSIGNED_LONG(x)	PyInt_FromLong(x)
+	#endif
+
+	#ifndef PYLONG_FROM_UNSIGNED_LONG_LONG
+	#define PYLONG_FROM_UNSIGNED_LONG_LONG(x)	PyInt_FromLong((long)x)
 	#endif
 
 	#ifndef PYSTRING_FROM_STRING

--- a/python/bindings/PyVideo.cpp
+++ b/python/bindings/PyVideo.cpp
@@ -223,8 +223,15 @@ static PyObject* PyVideoSource_Capture( PyVideoSource_Object* self, PyObject* ar
 		return NULL;
 	}
 
+	// expect raw image if conversion format is unknown
+	if (format == IMAGE_UNKNOWN)
+	{
+		// register memory capsule (videoSource will free the underlying memory when source is deleted)
+		return PyCUDA_RegisterImage(ptr, self->source->GetWidth(), self->source->GetHeight(), self->source->GetRawFormat(), self->source->GetLastTimestamp(), self->source->GetOptions().zeroCopy, false);
+	}
+
 	// register memory capsule (videoSource will free the underlying memory when source is deleted)
-	return PyCUDA_RegisterImage(ptr, self->source->GetWidth(), self->source->GetHeight(), format, self->source->GetOptions().zeroCopy, false);
+	return PyCUDA_RegisterImage(ptr, self->source->GetWidth(), self->source->GetHeight(), format, self->source->GetLastTimestamp(), self->source->GetOptions().zeroCopy, false);
 }
 
 // PyVideoSource_GetWidth

--- a/python/examples/camera-viewer.py
+++ b/python/examples/camera-viewer.py
@@ -46,9 +46,11 @@ camera.Open()
 
 # capture frames until user exits
 while display.IsOpen():
-	image, width, height = camera.CaptureRGBA()
+	# image, width, height = camera.CaptureRGBA(zeroCopy=False)
+	image, width, height = camera.Capture(format="rgb8")
+	print(image, image.timestamp)
 	display.RenderOnce(image, width, height)
-	display.SetTitle("{:s} | {:d}x{:d} | {:.1f} FPS".format("Camera Viewer", width, height, display.GetFPS()))
+	display.SetTitle("{:s} | {:d}x{:d} | {:.3f} sec | {:.1f} FPS".format("Camera Viewer", width, height, image.timestamp / 1.0e+9, display.GetFPS()))
 	
 # close the camera
 camera.Close()

--- a/timespec.h
+++ b/timespec.h
@@ -131,6 +131,12 @@ extern const timespec __apptime_begin__;
 inline void apptime( timespec* a )										{ timespec t; timestamp(&t); timeDiff(__apptime_begin__, t, a); }
 
 /**
+ * Retrieve the elapsed time since the process started (in nanoseconds).
+ * @ingroup time
+ */
+inline uint64_t apptime_nano()										{ timespec t; apptime(&t); return (uint64_t)t.tv_sec * uint64_t(1000000000) + (uint64_t)t.tv_nsec; }
+
+/**
  * Retrieve the elapsed time since the process started (in seconds).
  * @ingroup time
  */

--- a/video/videoSource.cpp
+++ b/video/videoSource.cpp
@@ -33,6 +33,8 @@
 videoSource::videoSource( const videoOptions& options ) : mOptions(options)
 {
 	mStreaming = false;
+	mLastTimestamp = 0;
+	mRawFormat = IMAGE_UNKNOWN;
 }
 
 

--- a/video/videoSource.h
+++ b/video/videoSource.h
@@ -258,6 +258,16 @@ public:
 	inline uint32_t GetFrameRate() const			{ return mOptions.frameRate; }
 
 	/**
+	 * Get timestamp of the last captured frame, in nanoseconds.
+ 	 */
+	uint64_t GetLastTimestamp() const { return mLastTimestamp; }
+
+	/**
+	 * Get raw image format.
+ 	 */
+	inline imageFormat GetRawFormat() const { return mRawFormat; }
+
+	/**
 	 * Return the resource URI of the stream.
 	 */
 	inline const URI& GetResource() const			{ return mOptions.resource; }
@@ -308,6 +318,9 @@ protected:
 
 	bool         mStreaming;
 	videoOptions mOptions;
+
+	uint64_t     mLastTimestamp;
+	imageFormat  mRawFormat;
 };
 
 #endif


### PR DESCRIPTION
Dear NVIDIA Jetson Development Team,

This pull request provides two contributions:

1. A timestamp field was added to definition of PyCudaImage and it is being populated using GST_BUFFER_DTS_OR_PTS macro for gstBuffer when capturing with gstCamera (lower jitter than if using timespec.h). The timestamp field is also preserved/populated when performing operations with PyCudaImage, such as image format conversion, crop, resize etc.

2. Image capture in raw format using gstCamera (see camera-viewer.py for usage example) was added. This is useful when one wants to do image format conversion later outside of gstCamera without being restricted to rgba formats only. Please note that I420 format is being treated as having width=1, height=1, and depth=img->base.size when mapping to numpy array in python bindings for convenience.

Thank you for considering this pull request!

Kind regards,
Yurii Piadyk, NYU