### PR TITLE
fix JetPack 5.x NVMM problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ include_directories(${PROJECT_INCLUDE_DIR}/jetson-utils)
 include_directories(/usr/include/gstreamer-1.0 /usr/include/glib-2.0 /usr/include/libxml2 /usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/gstreamer-1.0/include /usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/glib-2.0/include/)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+	include_directories(/usr/src/jetson_multimedia_api/include)
 	link_directories(/usr/lib/aarch64-linux-gnu/tegra)
 endif()
 

--- a/codec/gstBufferManager.cpp
+++ b/codec/gstBufferManager.cpp
@@ -28,6 +28,9 @@
 
 #ifdef ENABLE_NVMM
 #include <nvbuf_utils.h>
+#ifdef GST_CODECS_V4L2
+#include <nvbufsurface.h>
+#endif
 #include <cuda_egl_interop.h>
 #endif
 
@@ -160,11 +163,16 @@ bool gstBufferManager::Enqueue( GstBuffer* gstBuffer, GstCaps* gstCaps )
 		if( mFrameCount == 0 )
 			LogVerbose(LOG_GSTREAMER "gstBufferManager -- recieved NVMM memory\n");
 	
+#ifdef GST_CODECS_V4L2
+		NvBufSurface* surf = (NvBufSurface*)map.data;
+		nvmmFD = surf->surfaceList[0].bufferDesc;
+#else
 		if( ExtractFdFromNvBuffer(map.data, &nvmmFD) != 0 )
 		{
 			LogError(LOG_GSTREAMER "gstBufferManager -- failed to get FD from NVMM memory\n");
 			return false;
 		}
+#endif
 
 		NvBufferParams nvmmParams;
 	

--- a/codec/gstBufferManager.h
+++ b/codec/gstBufferManager.h
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef GST_CODECS_V4L2
-	#undef ENABLE_NVMM  // NVMM code having some issues on JetPack 5.x
+//	#undef ENABLE_NVMM  // NVMM code having some issues on JetPack 5.x
 #endif
 #endif
 


### PR DESCRIPTION
tried to fix JetPack 5.x NVMM problem, with help of NVIDIA forum user @dl1

https://forums.developer.nvidia.com/t/extractfdfromnvbuffer-fails-with-nvmap-ioc-get-fd-failed-invalid-argument/228859