### PR TITLE
fix -Wswitch (encountered on GCC - might also apply to CLang)

### DIFF
--- a/image/imageFormat.inl
+++ b/image/imageFormat.inl
@@ -52,10 +52,9 @@ inline const char* imageFormatToStr( imageFormat format )
 		case IMAGE_BAYER_RGGB:	return "bayer-rggb";
 		case IMAGE_GRAY8:	 	return "gray8";
 		case IMAGE_GRAY32F:  	return "gray32f";
-		case IMAGE_UNKNOWN: 	return "unknown";
+		case IMAGE_UNKNOWN:
+		default:				return "unknown";
 	};
-	
-	return "unknown";
 }
 
 // imageFormatIsRGB
@@ -143,12 +142,11 @@ inline imageBaseType imageFormatBaseType( imageFormat format )
 	{
 		case IMAGE_GRAY32F:
 		case IMAGE_RGB32F:
-		case IMAGE_BGR32F:		
+		case IMAGE_BGR32F:
 		case IMAGE_RGBA32F: 
 		case IMAGE_BGRA32F:		return IMAGE_FLOAT;
+		default:				return IMAGE_UINT8;
 	}
-
-	return IMAGE_UINT8;
 }
 
 
@@ -177,9 +175,8 @@ inline size_t imageFormatChannels( imageFormat format )
 		case IMAGE_BAYER_GBRG:
 		case IMAGE_BAYER_GRBG:
 		case IMAGE_BAYER_RGGB:	return 1;
+		default:				return 0;
 	}
-
-	return 0;
 }
 
 
@@ -208,9 +205,8 @@ inline size_t imageFormatDepth( imageFormat format )
 		case IMAGE_BAYER_GBRG:
 		case IMAGE_BAYER_GRBG:
 		case IMAGE_BAYER_RGGB:	return sizeof(unsigned char) * 8;
+		default:				return 0;
 	}
-
-	return 0;
 }
 
 


### PR DESCRIPTION
Including (recursively by other files (*cudaOverlay.h*)) *imageFormat.inl*, generates an (annoying) compiler warning:

```
.../jetson_utils/image/imageFormat.inl:187:8: warning: enumeration value 'IMAGE_COUNT' not handled in switch [-Wswitch]
```

Fix (without affecting the behavior).
