### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jetson-utils is typically built as a submodule of [jetson-inference](https://git
 
 ``` bash
 git clone https://github.com/dusty-nv/jetson-utils
+cd jetson-utils
 mkdir build
 cd build
 cmake ../


### PR DESCRIPTION
'cd jetson-utils' was missing in bash script which made build directory to be built outside of jetson-utils directory and hence building failed.