### PR TITLE
fix check for ReadOnce and ReadLatest flags

### DIFF
--- a/cpp/threads/RingBuffer.inl
+++ b/cpp/threads/RingBuffer.inl
@@ -141,7 +141,7 @@ inline void* RingBuffer::Peek( uint32_t flags )
 
 	if( flags & Write )
 		bufferIndex = (mLatestWrite + 1) % mNumBuffers;
-	else if( flags & ReadLatest )
+	else if( (flags & ReadLatest) == ReadLatest )
 		bufferIndex = mLatestWrite;
 	else if( flags & Read )
 		bufferIndex = mLatestRead;
@@ -181,14 +181,14 @@ inline void* RingBuffer::Next( uint32_t flags )
 		bufferIndex  = mLatestWrite;
 		mReadOnce    = false;
 	}
-	else if( (flags & ReadOnce) && mReadOnce )
+	else if( (flags & ReadOnce) == ReadOnce && mReadOnce )
 	{
 		if( flags & Threaded )
 			mMutex.Unlock();
 
 		return NULL;
 	}
-	else if( flags & ReadLatest )
+	else if( (flags & ReadLatest) == ReadLatest )
 	{
 		mLatestRead = mLatestWrite;
 		bufferIndex = mLatestWrite;


### PR DESCRIPTION
because all `ReadOnce`, `ReadLatest`, `ReadLatestOnce` flags are a combination of bits, when we check e.g. `flags & ReadOnce` this will succeed even if `flags` has any bit set from `ReadOnce` bitset.

In short:
```
flags = Read;
(flags & ReadOnce) is true
(flags & ReadLatest) is true
(flags & ReadLatestOnce) is true
```
so first condition in `Next` or `Peek` will always succeed disregarding of whether our flags have `Once/Latest` bits present
