### PR TITLE
Nvenc encode remove rendudant H-H memcpy x86 / wrap for jetson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,42 @@ get_directory_property(hasParent PARENT_DIRECTORY)
 
 if(hasParent)
 	message("-- jetson-utils:  building as submodule, ${hasParent}")
+
+	# this was originally meant for building with nvidia inference stuff and not needing to setup the cuda directories. We aren't doing that, so set them up.
+	set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cuda")
+	find_package(CUDA)
+	message("-- CUDA version: ${CUDA_VERSION}")
+
+	set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -O3)
+
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+		message("-- CUDA ${CUDA_VERSION} detected (${CMAKE_SYSTEM_PROCESSOR}), enabling SM_53 SM_62")
+		set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62)
+
+		if(CUDA_VERSION_MAJOR GREATER 9)
+			message("-- CUDA ${CUDA_VERSION} detected (${CMAKE_SYSTEM_PROCESSOR}), enabling SM_72")
+			set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -gencode arch=compute_72,code=sm_72)
+		endif()
+
+		if(CUDA_VERSION_MAJOR GREATER 10)
+			message("-- CUDA ${CUDA_VERSION} detected (${CMAKE_SYSTEM_PROCESSOR}), enabling SM_87")
+			set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -gencode arch=compute_87,code=sm_87)
+		endif()
+	endif()
+
+	# Use CMAKE_CURRENT_BINARY_DIR so it doesn't pollute the root project's binary dir
+	set(JETSON_UTILS_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_SYSTEM_PROCESSOR}")
+	set(JETSON_UTILS_INCLUDE_DIR "${JETSON_UTILS_OUTPUT_DIR}/include")
+
+	# Update the global-style variables for internal jetson-utils use
+	set(PROJECT_OUTPUT_DIR  ${JETSON_UTILS_OUTPUT_DIR})
+	set(PROJECT_INCLUDE_DIR ${JETSON_UTILS_INCLUDE_DIR})
+
+	# Ensure the directories exist
+	file(MAKE_DIRECTORY ${PROJECT_INCLUDE_DIR})
+	file(MAKE_DIRECTORY ${PROJECT_OUTPUT_DIR}/bin)
+	file(MAKE_DIRECTORY ${PROJECT_OUTPUT_DIR}/lib)
+
 else()
 	message("-- jetson-utils:  building as standalone")
 	
@@ -68,6 +104,49 @@ else()
 
 endif()
 
+find_package(CUDA REQUIRED)
+
+include_directories(
+	${CUDA_INCLUDE_DIRS}
+	/usr/local/include/jetson-utils
+	/usr/local/include/jetson-inference
+)
+
+# --- TensorRT Discovery ---
+# Allow users to pass -DTENSORRT_ROOT=/path/to/TRT via command line
+set(TENSORRT_ROOT "" CACHE PATH "Path to TensorRT SDK root")
+
+# Define search hints for different environments
+set(TRT_HINTS
+    ${TENSORRT_ROOT}
+    ${CMAKE_SOURCE_DIR}/../tensorrt  # Common if vendored
+    /opt/tensorrt-10.3              # Your specific x86 path
+    /usr/lib/x86_64-linux-gnu       # Standard x86
+    /usr/lib/aarch64-linux-gnu      # Standard Jetson
+)
+
+# 1. Search for headers
+find_path(TENSORRT_INCLUDE_DIR NvInfer.h
+    HINTS ${TRT_HINTS}
+    PATH_SUFFIXES include
+)
+
+# 2. Search for the library (Handles the nv_infer vs nvinfer name mismatch)
+find_library(TENSORRT_LIB 
+    NAMES nvinfer nv_infer
+    HINTS ${TRT_HINTS}
+    PATH_SUFFIXES lib lib64
+)
+
+if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIB)
+    message(STATUS "-- Found TensorRT: ${TENSORRT_LIB}")
+    include_directories(${TENSORRT_INCLUDE_DIR})
+    set(TRT_LIBRARIES ${TENSORRT_LIB})
+else()
+    # Fallback/Failure
+    message(FATAL_ERROR "TensorRT not found. Please set TENSORRT_ROOT or install dependencies.")
+endif()
+
 # option for enabling/disabling NVMM memory in multimedia stack
 find_library(NVBUF_UTILS NAMES nvbuf_utils PATHS /usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/tegra)
 message("-- nvbuf_utils:  ${NVBUF_UTILS}")
@@ -107,12 +186,22 @@ file(GLOB jetsonUtilsInc cpp/*/*.h cpp/*/*.hpp cpp/*/*.inl cuda/*.h cuda/*.cuh)
 
 cuda_add_library(jetson-utils SHARED ${jetsonUtilsSrc})
 
+target_include_directories(jetson-utils PUBLIC 
+    $<BUILD_INTERFACE:${PROJECT_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
 target_link_libraries( jetson-utils 
 	GL GLU GLEW ${CUDA_nppicc_LIBRARY}
 	gstreamer-1.0 gstapp-1.0 gstpbutils-1.0 
 	gstwebrtc-1.0 gstsdp-1.0 gstrtspserver-1.0 
-	json-glib-1.0 soup-2.4
-)	
+	json-glib-1.0 soup-2.4 ${TRT_LIBRARIES}
+)
+
+# Fix for C++20/C++23 where <cstdint> is no longer implicit
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_definitions(-include cstdint)
+endif()
 
 if(NVBUF_UTILS)
 	target_link_libraries(jetson-utils nvbuf_utils)
@@ -138,7 +227,7 @@ install(TARGETS jetson-utils DESTINATION lib EXPORT jetson-utilsConfig)
 install(EXPORT jetson-utilsConfig DESTINATION share/jetson-utils/cmake)
 
 # build python bindings
-add_subdirectory(python)
+# add_subdirectory(python)
 
 # build sample apps
 add_subdirectory(cpp/video/video-viewer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,8 @@ set(TENSORRT_ROOT "" CACHE PATH "Path to TensorRT SDK root")
 set(TRT_HINTS
     ${TENSORRT_ROOT}
     ${CMAKE_SOURCE_DIR}/../tensorrt  # Common if vendored
-    /opt/tensorrt-10.3              # Your specific x86 path
+    /opt/tensorrt-10.3
+	/opt/tensorrt-10.13				# support both versions of tensorrt
     /usr/lib/x86_64-linux-gnu       # Standard x86
     /usr/lib/aarch64-linux-gnu      # Standard Jetson
 )

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -423,7 +423,6 @@ bool gstEncoder::buildLaunchStr()
 			ss << "iframeinterval=";
 			#else
 		    ss << "bframes=0 ";
-			//ss << "byte-stream=true "; // byte stream sends SPS/PPS headers
 			ss << "key-int-max=";
 			#endif
 			ss << std::to_string(mOptions.maxIFrameInterval);

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -330,7 +330,7 @@ bool gstEncoder::buildLaunchStr()
 
 	ss << " ! ";
 
-	if ( mOptions.rescale && mOptions.output_width != 0 and mOptions.output_height != 0 ) {
+	if ( mOptions.codec != videoOptions::CODEC_H264 && mOptions.rescale && mOptions.output_width != 0 and mOptions.output_height != 0 ) {
 		ss << "videoconvert ! videoscale ! ";
 		ss << "video/x-raw,";
 		ss << "width=";
@@ -366,8 +366,17 @@ bool gstEncoder::buildLaunchStr()
 	}
 	
 	// the V4L2 encoders expect NVMM memory, so use nvvidconv to convert it
-	if( mOptions.codecType == videoOptions::CODEC_V4L2 && mOptions.codec != videoOptions::CODEC_MJPEG )
-		ss << "nvvidconv name=vidconv ! video/x-raw(memory:NVMM) ! ";
+	if( mOptions.codecType == videoOptions::CODEC_V4L2 && mOptions.codec != videoOptions::CODEC_MJPEG ){
+		ss << "nvvidconv name=vidconv ! video/x-raw(memory:NVMM)";
+		if (mOptions.codec == videoOptions::CODEC_H264 && mOptions.rescale && mOptions.output_width != 0 and mOptions.output_height != 0){
+			ss << ",width=";
+			ss << std::to_string(mOptions.output_width);
+			ss << ",height=";
+			ss << std::to_string(mOptions.output_height);
+		}
+
+		ss << " ! ";
+	}
 	
 	// setup the encoder and options
 	ss << encoder << " name=encoder ";
@@ -462,7 +471,7 @@ bool gstEncoder::buildLaunchStr()
 			ss << "rtpjpegpay";
 
 		if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 ) 
-			ss << " config-interval=-1";	// aggregate-mode=zero-latency";
+			ss << " config-interval=-1 aggregate-mode=1";
 
 		if (mOptions.payload_type != 0){
 			ss << " pt=";

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -314,15 +314,33 @@ bool gstEncoder::buildLaunchStr()
 		ss << " block=false";
 	}
 
-	ss << " !";
+	if( mOptions.input_is_rgb ) {
+		// This specifies that the input is RGB of the width and height
+		ss << " caps=\"video/x-raw,format=RGB";
+		ss << ",width=";
+		ss << std::to_string(mOptions.width);
+		ss << ",height=";
+		ss << std::to_string(mOptions.height);
+		ss << ",framerate=30/1\"";
+	}
 
-	if( mOptions.codecType == videoOptions::CODEC_CPU )
-    {
-		ss << "videoparse format=rgb width=" << mOptions.width 
-		<< " height=" << mOptions.height 
-		<< " framerate=" << (int)mOptions.frameRate << "/1 ! ";
-		ss << "videoconvert ! video/x-raw,format=I420 !";
-    }
+	ss << " ! ";
+
+	if ( mOptions.rescale && mOptions.output_width != 0 and mOptions.output_height != 0 ) {
+		ss << "videoconvert ! videoscale ! ";
+		ss << "video/x-raw,";
+		ss << "width=";
+		ss << std::to_string(mOptions.output_width);
+		ss << ",height=";
+		ss << std::to_string(mOptions.output_height);
+		ss << " ! ";
+	}
+
+	if ( mOptions.input_is_rgb ) {
+		// convert to the format needed by the encoder
+		ss << "videoconvert ! ";
+		ss << "video/x-raw,format=I420 ! ";
+	}
 	
 	const URI& uri = GetResource();
 	std::string encoderOptions = "";
@@ -428,7 +446,7 @@ bool gstEncoder::buildLaunchStr()
 		else if( mOptions.codec == videoOptions::CODEC_H265 )
 			ss << "rtph265pay";
 		else if( mOptions.codec == videoOptions::CODEC_VP8 )
-			ss << "rtpvp8pay";
+			ss << "rtpvp8pay picture-id-mode=15-bit";
 		else if( mOptions.codec == videoOptions::CODEC_VP9 )
 			ss << "rtpvp9pay";
 		else if( mOptions.codec == videoOptions::CODEC_MJPEG )

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -81,6 +81,9 @@ gstEncoder::gstEncoder( const videoOptions& options ) : videoOutput(options)
 	mNeedData     = false;
 
 	mBufferYUV.SetThreaded(false);
+
+	for( uint32_t n=0; n < YUVBufferCount; n++ )
+		mBufferBusy[n].store(false);
 }
 
 
@@ -582,8 +585,31 @@ void gstEncoder::onEnoughData( GstElement* pipeline, gpointer user_data )
 }
 
 
+// context handed to a wrapped GstBuffer's release callback
+struct gstYUVBufferRef
+{
+	gstEncoder* encoder;
+	int         slot;
+};
+
+
+// onBufferReleased
+void gstEncoder::onBufferReleased( void* user_data )
+{
+	gstYUVBufferRef* ref = (gstYUVBufferRef*)user_data;
+
+	if( !ref )
+		return;
+
+	if( ref->encoder != NULL && ref->slot >= 0 && ref->slot < (int)YUVBufferCount )
+		ref->encoder->mBufferBusy[ref->slot].store(false);
+
+	delete ref;
+}
+
+
 // encodeYUV
-bool gstEncoder::encodeYUV( void* buffer, size_t size )
+bool gstEncoder::encodeYUV( void* buffer, size_t size, int slot )
 {
 	if( !buffer || size == 0 )
 		return false;
@@ -629,32 +655,29 @@ bool gstEncoder::encodeYUV( void* buffer, size_t size )
 	}
 
 #if GST_CHECK_VERSION(1,0,0)
-	// allocate gstreamer buffer memory
-	GstBuffer* gstBuffer = gst_buffer_new_allocate(NULL, size, NULL);
-	
-	// map the buffer for write access
-	GstMapInfo map; 
+	// Wrap the ring-buffer slot directly into a GstBuffer instead of allocating a new
+	// buffer and memcpy'ing into it. The slot's memory is CUDA-accessible (ZeroCopy) and
+	// already holds this frame's I420 data (converted into it on Tegra, D2H-copied into it
+	// on discrete GPUs). The slot's busy flag is held until GStreamer frees the buffer
+	// (onBufferReleased), so Render() won't overwrite a slot still in flight downstream.
+	if( slot >= 0 && slot < (int)YUVBufferCount )
+		mBufferBusy[slot].store(true);
 
-	if( gst_buffer_map(gstBuffer, &map, GST_MAP_WRITE) ) 
-	{ 
-		if( map.size != size )
-		{
-			LogError(LOG_GSTREAMER "gstEncoder -- gst_buffer_map() size mismatch, got %zu bytes, expected %zu bytes\n", map.size, size);
-			gst_buffer_unref(gstBuffer);
-			return false;
-		}
-		memcpy(map.data, buffer, size);
-		gst_buffer_unmap(gstBuffer, &map);
-	} 
-	else
+	gstYUVBufferRef* bufferRef = new gstYUVBufferRef{ this, slot };
+
+	GstBuffer* gstBuffer = gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, buffer, size, 0, size, bufferRef, onBufferReleased);
+
+	if( !gstBuffer )
 	{
-		LogError(LOG_GSTREAMER "gstEncoder -- failed to map gstreamer buffer memory (%zu bytes)\n", size);
-		gst_buffer_unref(gstBuffer);
+		LogError(LOG_GSTREAMER "gstEncoder -- failed to wrap gstreamer buffer memory (%zu bytes)\n", size);
+		onBufferReleased(bufferRef);	// clears the busy flag and frees the ref
 		return false;
 	}
 #else
+	(void)slot;	// slot lifetime tracking only applies to the 1.0 zero-copy wrap path
+
 	// convert memory to GstBuffer
-	GstBuffer* gstBuffer = gst_buffer_new();	
+	GstBuffer* gstBuffer = gst_buffer_new();
 
 	GST_BUFFER_MALLOCDATA(gstBuffer) = (guint8*)g_malloc(size);
 	GST_BUFFER_DATA(gstBuffer) = GST_BUFFER_MALLOCDATA(gstBuffer);
@@ -773,10 +796,11 @@ bool gstEncoder::Render( void* image, uint32_t width, uint32_t height, imageForm
 
 	// allocate color conversion buffer
 	const size_t i420Size = imageFormatSize(IMAGE_I420, width, height);
-	// nextYUV must be host-mapped (ZeroCopy): the x86 convert path bulk-copies I420 D->H
-	// into it and encodeYUV() memcpy's from it on the CPU. RingBuffer::Threaded (no ZeroCopy)
-	// allocates device-only memory (cudaMalloc), which makes that CPU memcpy segfault.
-	if( !mBufferYUV.Alloc(2, i420Size, RingBuffer::ZeroCopy) )
+	// nextYUV must be host-mapped (ZeroCopy): on Tegra the convert kernel writes I420 straight
+	// into it, on discrete GPUs the I420 image is bulk-copied D->H into it. It is then wrapped
+	// zero-copy into a GstBuffer (no host memcpy). RingBuffer::Threaded (no ZeroCopy) allocates
+	// device-only memory (cudaMalloc), which is not CPU/GStreamer-accessible.
+	if( !mBufferYUV.Alloc(YUVBufferCount, i420Size, RingBuffer::ZeroCopy) )
 	{
 		LogError(LOG_GSTREAMER "gstEncoder -- failed to allocate buffers (%zu bytes each)\n", i420Size);
 		enc_success = false;
@@ -785,6 +809,19 @@ bool gstEncoder::Render( void* image, uint32_t width, uint32_t height, imageForm
 
 	// perform colorspace conversion
 	void* nextYUV = mBufferYUV.Next(RingBuffer::Write);
+	const int yuvSlot = (int)mBufferYUV.GetLatestWrite();
+
+	// don't reuse a slot that GStreamer is still holding downstream (wrapped zero-copy).
+	// With YUVBufferCount slots >> pipeline depth this is essentially never hit, but if it
+	// is, skip this frame rather than corrupt an in-flight buffer.
+	if( mBufferBusy[yuvSlot].load() )
+	{
+		if( mOptions.frameCount % 25 == 0 )
+			LogVerbose(LOG_GSTREAMER "gstEncoder -- all YUV push buffers in flight, skipping frame %zu\n", mOptions.frameCount);
+
+		enc_success = true;
+		render_end();
+	}
 
 #if defined(__aarch64__)
 	// Tegra: nextYUV is unified memory, so convert straight into it.
@@ -828,8 +865,8 @@ bool gstEncoder::Render( void* image, uint32_t width, uint32_t height, imageForm
     else
 	    CUDA(cudaDeviceSynchronize());
 	
-	// encode YUV buffer
-	enc_success = encodeYUV(nextYUV, i420Size);
+	// encode YUV buffer (wrapped zero-copy from ring slot yuvSlot)
+	enc_success = encodeYUV(nextYUV, i420Size, yuvSlot);
 
 	// render sub-streams
 	render_end();	

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -432,8 +432,12 @@ bool gstEncoder::buildLaunchStr()
 
 	}
 
-	if( mOptions.codec == videoOptions::CODEC_H264 )
-		ss << "! video/x-h264,profile=constrained-baseline ! ";
+	if( mOptions.codec == videoOptions::CODEC_H264 ) {
+	    ss << "! video/x-h264,profile=constrained-baseline ! ";
+#ifndef __aarch64__
+	    ss<<" h264parse config-interval=1 ! ";
+#endif
+	}
 	else if( mOptions.codec == videoOptions::CODEC_H265 )
 		ss << "! video/x-h265 ! ";
 	else if( mOptions.codec == videoOptions::CODEC_VP8 )
@@ -442,9 +446,7 @@ bool gstEncoder::buildLaunchStr()
 		ss << "! video/x-vp9 ! ";
 	else if( mOptions.codec == videoOptions::CODEC_MJPEG )
 		ss << "! image/jpeg ! ";
-#ifndef __aarch64__
-    ss<<" h264parse config-interval=1 ! ";
-#endif
+
 	if( mOptions.save.path.length() > 0 )
 	{
 		ss << "tee name=savetee savetee. ! queue ! ";

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -380,8 +380,15 @@ bool gstEncoder::buildLaunchStr()
 	
 	// setup the encoder and options
 	ss << encoder << " name=encoder ";
-	
-	if( mOptions.codecType == videoOptions::CODEC_CPU )
+
+	if( strncmp(encoder, "nvh264enc", 9) == 0 )
+	{
+		// desktop NVENC (nvcodec): bitrate is in kbit/sec (like x264enc). Only set bitrate and rely
+		// on element defaults for everything else, so the pipeline launches regardless of nvcodec
+		// plugin version (preset/rc-mode/zerolatency property names vary across versions).
+		ss << "bitrate=" << mOptions.bitRate / 1000 << " ";
+	}
+	else if( mOptions.codecType == videoOptions::CODEC_CPU )
 	{
 		if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 )
 		{
@@ -420,13 +427,13 @@ bool gstEncoder::buildLaunchStr()
 				mOptions.maxIFrameInterval = 30;
 			}
 			#ifdef __aarch64__
-			ss << "iframeinterval=";
+			ss << "iframeinterval=" << std::to_string(mOptions.maxIFrameInterval) << " insert-vui=1 ";
 			#else
-		    ss << "bframes=0 ";
-			ss << "key-int-max=";
+			if( strncmp(encoder, "nvh264enc", 9) == 0 )
+				ss << "bframes=0 gop-size=" << std::to_string(mOptions.maxIFrameInterval) << " ";  // nvcodec: gop-size, no key-int-max/insert-vui
+			else
+				ss << "bframes=0 key-int-max=" << std::to_string(mOptions.maxIFrameInterval) << " insert-vui=1 ";
 			#endif
-			ss << std::to_string(mOptions.maxIFrameInterval);
-			ss << " insert-vui=1 ";		
 		}	
 
 	}
@@ -778,15 +785,39 @@ bool gstEncoder::Render( void* image, uint32_t width, uint32_t height, imageForm
 	// perform colorspace conversion
 	void* nextYUV = mBufferYUV.Next(RingBuffer::Write);
 
-	if( CUDA_FAILED(cudaConvertColor(image, format, nextYUV, IMAGE_I420, width, height, stream)) )
+#if defined(__aarch64__)
+	// Tegra: nextYUV is unified memory, so convert straight into it.
+	const bool convert_ok = !CUDA_FAILED(cudaConvertColor(image, format, nextYUV, IMAGE_I420, width, height, stream));
+#else
+	// Discrete GPU (x86): nextYUV is ZeroCopy (host-mapped) memory. Converting RGB->I420 directly
+	// into it scatters per-pixel writes across PCIe (~12ms/frame - this dominated the GPU). Instead
+	// convert into a device buffer (coalesced device writes, sub-ms) then do a single bulk D2H copy
+	// into the host push buffer. thread_local: each stream's Render runs on its own dedicated thread,
+	// so the per-thread device buffer avoids any cross-encoder race.
+	bool convert_ok = false;
+	{
+		thread_local void* s_dev_i420 = nullptr;
+		thread_local size_t s_dev_size = 0;
+		if( s_dev_size < i420Size )
+		{
+			if( s_dev_i420 ) cudaFree(s_dev_i420);
+			if( CUDA_FAILED(cudaMalloc(&s_dev_i420, i420Size)) ) { s_dev_i420 = nullptr; s_dev_size = 0; }
+			else s_dev_size = i420Size;
+		}
+		if( s_dev_i420 && !CUDA_FAILED(cudaConvertColor(image, format, s_dev_i420, IMAGE_I420, width, height, stream)) )
+			convert_ok = !CUDA_FAILED(cudaMemcpyAsync(nextYUV, s_dev_i420, i420Size, cudaMemcpyDeviceToHost, stream));
+	}
+#endif
+
+	if( !convert_ok )
 	{
 		LogError(LOG_GSTREAMER "gstEncoder::Render() -- unsupported image format (%s)\n", imageFormatToStr(format));
 		LogError(LOG_GSTREAMER "                        supported formats are:\n");
-		LogError(LOG_GSTREAMER "                            * rgb8\n");		
-		LogError(LOG_GSTREAMER "                            * rgba8\n");		
-		LogError(LOG_GSTREAMER "                            * rgb32f\n");		
+		LogError(LOG_GSTREAMER "                            * rgb8\n");
+		LogError(LOG_GSTREAMER "                            * rgba8\n");
+		LogError(LOG_GSTREAMER "                            * rgb32f\n");
 		LogError(LOG_GSTREAMER "                            * rgba32f\n");
-		
+
 		enc_success = false;
 		render_end();
 	}

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -308,7 +308,21 @@ bool gstEncoder::buildCapsStr()
 bool gstEncoder::buildLaunchStr()
 {
 	std::ostringstream ss;
-	ss << "appsrc name=mysource is-live=true do-timestamp=true format=3 ! ";  // setup appsrc input element
+	ss << "appsrc name=mysource is-live=true do-timestamp=true format=3";  // setup appsrc input element
+
+	if( !mOptions.block){
+		ss << " block=false";
+	}
+
+	ss << " !";
+
+	if( mOptions.codecType == videoOptions::CODEC_CPU )
+    {
+		ss << "videoparse format=rgb width=" << mOptions.width 
+		<< " height=" << mOptions.height 
+		<< " framerate=" << (int)mOptions.frameRate << "/1 ! ";
+		ss << "videoconvert ! video/x-raw,format=I420 !";
+    }
 	
 	const URI& uri = GetResource();
 	std::string encoderOptions = "";
@@ -342,9 +356,6 @@ bool gstEncoder::buildLaunchStr()
 		{
 			ss << "bitrate=" << mOptions.bitRate / 1000 << " ";	// x264enc/x265enc bitrates are in kbits
 			ss << "speed-preset=ultrafast tune=zerolatency ";
-			
-			if( mOptions.deviceType == videoOptions::DEVICE_IP )
-				ss << "key-int-max=30 insert-vui=1 ";			// send keyframes/I-frames more frequently for network streams
 		}
 		else if( mOptions.codec == videoOptions::CODEC_VP8 || mOptions.codec == videoOptions::CODEC_VP9 )
 		{
@@ -368,6 +379,20 @@ bool gstEncoder::buildLaunchStr()
 		
 		if( mOptions.codecType == videoOptions::CODEC_V4L2 )
 			ss << "maxperf-enable=1 ";
+	}
+
+	if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 )
+	{
+		// send keyframes/I-frames more frequently for network streams
+		if( mOptions.deviceType == videoOptions::DEVICE_IP ) {
+			if (mOptions.maxIFrameInterval == 0){
+				mOptions.maxIFrameInterval = 30;
+			}
+			ss << "key-int-max=";
+			ss << std::to_string(mOptions.maxIFrameInterval);
+			ss << " insert-vui=1 ";		
+		}	
+
 	}
 
 	if( mOptions.codec == videoOptions::CODEC_H264 )
@@ -411,7 +436,17 @@ bool gstEncoder::buildLaunchStr()
 
 		if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 ) 
 			ss << " config-interval=1";	// aggregate-mode=zero-latency";
+
+		if (mOptions.payload_type != 0){
+			ss << " pt=";
+			ss << std::to_string(mOptions.payload_type);
+		}
 		
+		if (mOptions.ssrc != 0){
+			ss << " ssrc=";
+			ss << std::to_string(mOptions.ssrc);
+		}
+
 		if( uri.protocol == "rtsp" )
 			ss << " name=pay0";	 // GstRTSPServer expects the payloaders to be named pay0, pay1, ect
 		else
@@ -462,6 +497,8 @@ bool gstEncoder::buildLaunchStr()
 		LogError(LOG_GSTREAMER "gstEncoder -- invalid protocol (%s)\n", uri.protocol.c_str());
 		return false;
 	}
+
+	ss << " sync=false";
 
 	mLaunchStr = ss.str();
 

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -410,7 +410,12 @@ bool gstEncoder::buildLaunchStr()
 			if (mOptions.maxIFrameInterval == 0){
 				mOptions.maxIFrameInterval = 30;
 			}
+			#ifdef __aarch64__
+			ss << "iframeinterval=";
+			#else
+			ss << "byte-stream=true "; // byte stream sends SPS/PPS headers
 			ss << "key-int-max=";
+			#endif
 			ss << std::to_string(mOptions.maxIFrameInterval);
 			ss << " insert-vui=1 ";		
 		}	
@@ -418,7 +423,7 @@ bool gstEncoder::buildLaunchStr()
 	}
 
 	if( mOptions.codec == videoOptions::CODEC_H264 )
-		ss << "! video/x-h264 ! ";
+		ss << "! video/x-h264,profile=constrained-baseline,stream-format=byte-stream ! ";
 	else if( mOptions.codec == videoOptions::CODEC_H265 )
 		ss << "! video/x-h265 ! ";
 	else if( mOptions.codec == videoOptions::CODEC_VP8 )
@@ -457,7 +462,7 @@ bool gstEncoder::buildLaunchStr()
 			ss << "rtpjpegpay";
 
 		if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 ) 
-			ss << " config-interval=1";	// aggregate-mode=zero-latency";
+			ss << " config-interval=-1";	// aggregate-mode=zero-latency";
 
 		if (mOptions.payload_type != 0){
 			ss << " pt=";

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -171,7 +171,7 @@ bool gstEncoder::initPipeline()
 	}
 
 	// check if default framerate is needed
-	if( mOptions.frameRate <= 0 )
+	if( mOptions.frameRate < 0 )
 		mOptions.frameRate = 30;
 
 	// set default bitrate if needed
@@ -321,11 +321,11 @@ bool gstEncoder::buildLaunchStr()
 		ss << std::to_string(mOptions.width);
 		ss << ",height=";
 		ss << std::to_string(mOptions.height);
-		ss << ",framerate=30/1\"";
+		ss << ",framerate="<<std::to_string(mOptions.frameRate)<<"/1\"";
 	}
 
 	if (mOptions.latestOnly) {
-		ss << " ! queue max-size-buffers=1 leaky=downstream";
+		ss << " ! queue max-size-buffers=3 leaky=downstream";
 	}
 
 	ss << " ! ";
@@ -386,7 +386,7 @@ bool gstEncoder::buildLaunchStr()
 		if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 )
 		{
 			ss << "bitrate=" << mOptions.bitRate / 1000 << " ";	// x264enc/x265enc bitrates are in kbits
-			ss << "speed-preset=ultrafast tune=zerolatency ";
+			ss << "speed-preset=ultrafast tune=zerolatency peak-bitrate=30000000 control-rate=1 vbv-size=450000";
 		}
 		else if( mOptions.codec == videoOptions::CODEC_VP8 || mOptions.codec == videoOptions::CODEC_VP9 )
 		{
@@ -471,7 +471,7 @@ bool gstEncoder::buildLaunchStr()
 			ss << "rtpjpegpay";
 
 		if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 ) 
-			ss << " config-interval=-1 aggregate-mode=1";
+			ss << " config-interval=1 aggregate-mode=1 mtu=1400";
 
 		if (mOptions.payload_type != 0){
 			ss << " pt=";

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -386,7 +386,7 @@ bool gstEncoder::buildLaunchStr()
 		if( mOptions.codec == videoOptions::CODEC_H264 || mOptions.codec == videoOptions::CODEC_H265 )
 		{
 			ss << "bitrate=" << mOptions.bitRate / 1000 << " ";	// x264enc/x265enc bitrates are in kbits
-			ss << "speed-preset=ultrafast tune=zerolatency peak-bitrate=30000000 control-rate=1 vbv-size=450000";
+			ss << "speed-preset=ultrafast tune=zerolatency ";
 		}
 		else if( mOptions.codec == videoOptions::CODEC_VP8 || mOptions.codec == videoOptions::CODEC_VP9 )
 		{
@@ -403,7 +403,7 @@ bool gstEncoder::buildLaunchStr()
 		if( mOptions.deviceType == videoOptions::DEVICE_IP )
 		{
 			if( mOptions.codecType == videoOptions::CODEC_V4L2 )
-				ss << "insert-sps-pps=1 insert-vui=1 idrinterval=30 ";
+				ss << "insert-sps-pps=1 insert-vui=1 idrinterval=30 peak-bitrate=30000000 control-rate=1 vbv-size=450000";
 			else if( mOptions.codecType == videoOptions::CODEC_OMX )
 				ss << "insert-sps-pps=1 insert-vui=1 ";
 		}
@@ -422,7 +422,8 @@ bool gstEncoder::buildLaunchStr()
 			#ifdef __aarch64__
 			ss << "iframeinterval=";
 			#else
-			ss << "byte-stream=true "; // byte stream sends SPS/PPS headers
+		    ss << "bframes=0 ";
+			//ss << "byte-stream=true "; // byte stream sends SPS/PPS headers
 			ss << "key-int-max=";
 			#endif
 			ss << std::to_string(mOptions.maxIFrameInterval);
@@ -432,7 +433,7 @@ bool gstEncoder::buildLaunchStr()
 	}
 
 	if( mOptions.codec == videoOptions::CODEC_H264 )
-		ss << "! video/x-h264,profile=constrained-baseline,stream-format=byte-stream ! ";
+		ss << "! video/x-h264,profile=constrained-baseline ! ";
 	else if( mOptions.codec == videoOptions::CODEC_H265 )
 		ss << "! video/x-h265 ! ";
 	else if( mOptions.codec == videoOptions::CODEC_VP8 )
@@ -441,7 +442,9 @@ bool gstEncoder::buildLaunchStr()
 		ss << "! video/x-vp9 ! ";
 	else if( mOptions.codec == videoOptions::CODEC_MJPEG )
 		ss << "! image/jpeg ! ";
-	
+#ifndef __aarch64__
+    ss<<" h264parse config-interval=1 ! ";
+#endif
 	if( mOptions.save.path.length() > 0 )
 	{
 		ss << "tee name=savetee savetee. ! queue ! ";
@@ -494,7 +497,7 @@ bool gstEncoder::buildLaunchStr()
 
 			if( uri.port != 0 )
 				ss << "port=" << uri.port;
-
+            ss << " buffer-size=2000000";
 			ss << " auto-multicast=true";
 		}
 		else if( uri.protocol == "webrtc" )

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -33,14 +33,14 @@
 #include "cudaColorspace.h"
 
 #define GST_USE_UNSTABLE_API
-#include <gst/webrtc/webrtc.h>
 #include <gst/app/gstappsrc.h>
-
-#include <sstream>
+#include <gst/webrtc/webrtc.h>
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
 
+#include <boost/beast/websocket/stream.hpp>
+#include <sstream>
 
 // supported video file extensions
 const char* gstEncoder::SupportedExtensions[] = { "mkv", "mp4", "qt", 
@@ -643,9 +643,8 @@ bool gstEncoder::encodeYUV( void* buffer, size_t size )
 			gst_buffer_unref(gstBuffer);
 			return false;
 		}
-		
 		memcpy(map.data, buffer, size);
-		gst_buffer_unmap(gstBuffer, &map); 
+		gst_buffer_unmap(gstBuffer, &map);
 	} 
 	else
 	{
@@ -774,8 +773,11 @@ bool gstEncoder::Render( void* image, uint32_t width, uint32_t height, imageForm
 
 	// allocate color conversion buffer
 	const size_t i420Size = imageFormatSize(IMAGE_I420, width, height);
-
+#if defined(__aarch64__)
 	if( !mBufferYUV.Alloc(2, i420Size, RingBuffer::ZeroCopy) )
+#else
+    if( !mBufferYUV.Alloc(2, i420Size, RingBuffer::Threaded) )
+#endif
 	{
 		LogError(LOG_GSTREAMER "gstEncoder -- failed to allocate buffers (%zu bytes each)\n", i420Size);
 		enc_success = false;

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -324,6 +324,10 @@ bool gstEncoder::buildLaunchStr()
 		ss << ",framerate=30/1\"";
 	}
 
+	if (mOptions.latestOnly) {
+		ss << " ! queue max-size-buffers=1 leaky=downstream";
+	}
+
 	ss << " ! ";
 
 	if ( mOptions.rescale && mOptions.output_width != 0 and mOptions.output_height != 0 ) {

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -403,7 +403,7 @@ bool gstEncoder::buildLaunchStr()
 		if( mOptions.deviceType == videoOptions::DEVICE_IP )
 		{
 			if( mOptions.codecType == videoOptions::CODEC_V4L2 )
-				ss << "insert-sps-pps=1 insert-vui=1 idrinterval=30 peak-bitrate=30000000 control-rate=1 vbv-size=450000";
+				ss << "insert-sps-pps=1 insert-vui=1 idrinterval=30 peak-bitrate=30000000 control-rate=1 vbv-size=450000 ";
 			else if( mOptions.codecType == videoOptions::CODEC_OMX )
 				ss << "insert-sps-pps=1 insert-vui=1 ";
 		}

--- a/cpp/codec/gstEncoder.cpp
+++ b/cpp/codec/gstEncoder.cpp
@@ -773,11 +773,10 @@ bool gstEncoder::Render( void* image, uint32_t width, uint32_t height, imageForm
 
 	// allocate color conversion buffer
 	const size_t i420Size = imageFormatSize(IMAGE_I420, width, height);
-#if defined(__aarch64__)
+	// nextYUV must be host-mapped (ZeroCopy): the x86 convert path bulk-copies I420 D->H
+	// into it and encodeYUV() memcpy's from it on the CPU. RingBuffer::Threaded (no ZeroCopy)
+	// allocates device-only memory (cudaMalloc), which makes that CPU memcpy segfault.
 	if( !mBufferYUV.Alloc(2, i420Size, RingBuffer::ZeroCopy) )
-#else
-    if( !mBufferYUV.Alloc(2, i420Size, RingBuffer::Threaded) )
-#endif
 	{
 		LogError(LOG_GSTREAMER "gstEncoder -- failed to allocate buffers (%zu bytes each)\n", i420Size);
 		enc_success = false;

--- a/cpp/codec/gstEncoder.h
+++ b/cpp/codec/gstEncoder.h
@@ -27,6 +27,8 @@
 #include "videoOutput.h"
 #include "RingBuffer.h"
 
+#include <atomic>
+
 
 // Forward declarations
 class RTSPServer;
@@ -140,11 +142,15 @@ protected:
 	void checkMsgBus();
 	bool buildCapsStr();
 	bool buildLaunchStr();
-	bool encodeYUV( void* buffer, size_t size );
-	
+	bool encodeYUV( void* buffer, size_t size, int slot );
+
 	// appsrc callbacks
 	static void onNeedData( GstElement* pipeline, uint32_t size, void* user_data );
 	static void onEnoughData( GstElement* pipeline, void* user_data );
+
+	// GDestroyNotify invoked when GStreamer releases a zero-copy YUV buffer,
+	// clearing the busy flag for the ring slot it wrapped.
+	static void onBufferReleased( void* user_data );
 
 	// WebRTC callbacks
 	static void onWebsocketMessage( WebRTCPeer* peer, const char* message, size_t message_size, void* user_data );
@@ -158,8 +164,13 @@ protected:
 	std::string  mCapsStr;
 	std::string  mLaunchStr;
 
+	// YUV push buffers are wrapped into GstBuffers zero-copy (no host memcpy). Each slot
+	// stays "busy" until GStreamer frees the wrapped buffer, so Render() won't overwrite a
+	// slot still referenced downstream. Sized well above the pipeline's in-flight depth.
+	static const uint32_t YUVBufferCount = 8;
 	RingBuffer mBufferYUV;
-	
+	std::atomic<bool> mBufferBusy[YUVBufferCount];
+
 	RTSPServer*   mRTSPServer;
 	WebRTCServer* mWebRTCServer;
 };

--- a/cpp/codec/gstUtility.cpp
+++ b/cpp/codec/gstUtility.cpp
@@ -569,7 +569,20 @@ const char* gst_select_encoder( videoOptions::Codec codec, videoOptions::CodecTy
 	
 	if( codec == videoOptions::CODEC_RAW )
 		type = videoOptions::CODEC_CPU;
-	
+
+#if defined(__x86_64__) || defined(__amd64__)
+	// Desktop NVENC opt-in (GUNCAM_NVENC=1). jetson-utils has no native NVENC path (see the
+	// CODEC_NVENC TODO above), but the GStreamer nvcodec plugin's nvh264enc encodes on the GPU's
+	// dedicated ENC engine (off the SM and CPU). It accepts system-memory I420 and uploads to NVENC
+	// internally, so it drops in where x264enc would go with no pipeline-memory changes.
+	if( codec == videoOptions::CODEC_H264 )
+	{
+		const char* nvenc_env = getenv("GUNCAM_NVENC");
+		if( nvenc_env && nvenc_env[0] == '1' )
+			return "nvh264enc";
+	}
+#endif
+
 	if( type == videoOptions::CODEC_CPU )
 	{
 		switch(codec)

--- a/cpp/codec/gstUtility.cpp
+++ b/cpp/codec/gstUtility.cpp
@@ -575,6 +575,7 @@ const char* gst_select_encoder( videoOptions::Codec codec, videoOptions::CodecTy
 	// CODEC_NVENC TODO above), but the GStreamer nvcodec plugin's nvh264enc encodes on the GPU's
 	// dedicated ENC engine (off the SM and CPU). It accepts system-memory I420 and uploads to NVENC
 	// internally, so it drops in where x264enc would go with no pipeline-memory changes.
+	// Opt-in only: default stays software x264enc so CI / non-NVENC environments are unaffected.
 	if( codec == videoOptions::CODEC_H264 )
 	{
 		const char* nvenc_env = getenv("GUNCAM_NVENC");

--- a/cpp/threads/RingBuffer.h
+++ b/cpp/threads/RingBuffer.h
@@ -85,6 +85,13 @@ public:
 	inline void* Next( uint32_t flags );
 
 	/**
+	 * Get the index of the buffer most recently returned by Next(Write).
+	 * Valid after at least one Next(Write) call; useful for tracking the
+	 * lifetime of a specific slot when buffers are handed off zero-copy.
+	 */
+	inline uint32_t GetLatestWrite() const	{ return mLatestWrite; }
+
+	/**
 	 * Get the flags of the ring buffer.
 	 */
 	inline uint32_t GetFlags() const;

--- a/cpp/video/videoOptions.cpp
+++ b/cpp/video/videoOptions.cpp
@@ -43,6 +43,10 @@ videoOptions::videoOptions()
 	ssrc = 0;
 	payload_type = 0;
 	block = true;
+	rescale = false;
+	output_width = 0;
+	output_height = 0;
+	input_is_rgb = false;
 	ioType      = INPUT;
 	deviceType  = DEVICE_DEFAULT;
 	flipMethod  = FLIP_DEFAULT;

--- a/cpp/video/videoOptions.cpp
+++ b/cpp/video/videoOptions.cpp
@@ -39,6 +39,10 @@ videoOptions::videoOptions()
 	loop        = 0;
 	latency     = 10;
 	zeroCopy    = true;
+	maxIFrameInterval = 0;
+	ssrc = 0;
+	payload_type = 0;
+	block = true;
 	ioType      = INPUT;
 	deviceType  = DEVICE_DEFAULT;
 	flipMethod  = FLIP_DEFAULT;

--- a/cpp/video/videoOptions.cpp
+++ b/cpp/video/videoOptions.cpp
@@ -44,6 +44,7 @@ videoOptions::videoOptions()
 	payload_type = 0;
 	block = true;
 	rescale = false;
+	latestOnly = false;
 	output_width = 0;
 	output_height = 0;
 	input_is_rgb = false;

--- a/cpp/video/videoOptions.h
+++ b/cpp/video/videoOptions.h
@@ -147,6 +147,26 @@ public:
 	int latency;
 
 	/**
+	 * Whether or not to rescale the image. If this is set, output_width and output_height need to be set as well
+	 */
+	bool rescale;
+
+	/**
+	 * The width after rescaling
+	 */
+	uint32_t output_width;
+
+	/**
+	 * The height after rescaling
+	 */
+	uint32_t output_height;
+
+	/**
+	 * Some encoders need to have the image converted out of RGB before it reaches them
+	 */
+	bool input_is_rgb;
+
+	/**
 	 * Device interface types.
 	 */
 	enum DeviceType

--- a/cpp/video/videoOptions.h
+++ b/cpp/video/videoOptions.h
@@ -102,6 +102,26 @@ public:
 	 * @note the default is true (zeroCopy CPU/GPU access enabled).
 	 */
 	bool zeroCopy;
+
+	/**
+	 * The maximum number of frames between Iframes. 0 means to use the default.
+	 */
+	uint32_t maxIFrameInterval;
+
+	/**
+	 * The SSRC value to initialize the stream with, 0 for random / unassigned
+	 */
+	uint32_t ssrc;
+
+	/**
+	 * The payload type option for the stream. 0 for default
+	 */
+	uint8_t payload_type;
+
+	/**
+	 * The `block` flag, whether or not to have the encoder block on trying to send an image
+	 */
+	bool block;
 	
 	/**
 	 * Control the number of loops for videoSource disk-based inputs (for example,

--- a/cpp/video/videoOptions.h
+++ b/cpp/video/videoOptions.h
@@ -152,6 +152,11 @@ public:
 	bool rescale;
 
 	/**
+	 * Only care about the latest image, don't buffer more than one
+	 */
+	bool latestOnly;
+
+	/**
 	 * The width after rescaling
 	 */
 	uint32_t output_width;


### PR DESCRIPTION
 x86 (discrete): s_dev_i420  (still needed to avoid the PCIe scatter). The single D2H copy now lands in the ring slot, which is then wrapped — extra host memcpy is gone.

jetson (aarch64): convert kernel writes straight into the CUDA-mapped ring slot (as before), which is then wrapped  as a plain gst_buffer_new_allocate buffer isn't CUDA-kernel-accessible.



